### PR TITLE
Feature: capture from multiple keys

### DIFF
--- a/src/DefinitionDumper.php
+++ b/src/DefinitionDumper.php
@@ -106,13 +106,14 @@ CODE;
 
     private function dumpPropertyDefinition(PropertyDefinition $propertyDefinition): string
     {
+        $keys = var_export($propertyDefinition->keys, true);
         $propertyCasters = var_export($propertyDefinition->propertyCasters, true);
         $canBeHydrated = var_export($propertyDefinition->canBeHydrated, true);
         $isEnum = var_export($propertyDefinition->isEnum, true);
         $concreteTypeName = var_export($propertyDefinition->concreteTypeName, true);
         return <<<CODE
             new PropertyDefinition(
-                '$propertyDefinition->key',
+                $keys,
                 '$propertyDefinition->property',
                 $propertyCasters,
                 $canBeHydrated,

--- a/src/Fixtures/ClassThatRenamesInputForClassWithMultipleProperties.php
+++ b/src/Fixtures/ClassThatRenamesInputForClassWithMultipleProperties.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\MapFrom;
+
+class ClassThatRenamesInputForClassWithMultipleProperties
+{
+    public function __construct(
+
+        #[MapFrom(['mapped_age' => 'age', 'name'])]
+        public ClassWithMultipleProperties $child,
+    ) {
+    }
+}

--- a/src/Fixtures/ClassThatUsesClassWithMultipleProperties.php
+++ b/src/Fixtures/ClassThatUsesClassWithMultipleProperties.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\MapFrom;
+
+class ClassThatUsesClassWithMultipleProperties
+{
+    public function __construct(
+
+        public string $value,
+        #[MapFrom(['age', 'name'])]
+        public ClassWithMultipleProperties $child,
+    ) {
+    }
+}

--- a/src/Fixtures/ClassWithMultipleProperties.php
+++ b/src/Fixtures/ClassWithMultipleProperties.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+class ClassWithMultipleProperties
+{
+    public function __construct(
+        public int $age,
+        public string $name,
+    ) {
+    }
+}

--- a/src/MapFrom.php
+++ b/src/MapFrom.php
@@ -6,10 +6,23 @@ namespace EventSauce\ObjectHydrator;
 
 use Attribute;
 
+use function is_int;
+use function is_string;
+
 #[Attribute(Attribute::TARGET_PARAMETER)]
 class MapFrom
 {
-    public function __construct(public string $name)
+    /** @var array<string, string> */
+    public array $keys = [];
+
+    public function __construct(string|array $keyOrMap)
     {
+        if (is_string($keyOrMap)) {
+            $this->keys[$keyOrMap] = $keyOrMap;
+        } else {
+            foreach ($keyOrMap as $index => $key) {
+                $this->keys[is_int($index) ? $key : $index] = $key;
+            }
+        }
     }
 }

--- a/src/ObjectHydrator.php
+++ b/src/ObjectHydrator.php
@@ -6,6 +6,9 @@ namespace EventSauce\ObjectHydrator;
 
 use Throwable;
 
+use function array_key_exists;
+use function count;
+use function current;
 use function is_array;
 
 /**
@@ -39,10 +42,20 @@ class ObjectHydrator
             $properties = [];
 
             foreach ($classDefinition->propertyDefinitions as $definition) {
-                $value = $payload[$definition->key] ?? null;
+                $value = [];
 
-                if ($value === null) {
+                foreach ($definition->keys as $from => $to) {
+                    if (array_key_exists($from, $payload)) {
+                        $value[$to] = $payload[$from];
+                    }
+                }
+
+                if ($value === []) {
                     continue;
+                }
+
+                if (count($definition->keys) === 1) {
+                    $value = current($value);
                 }
 
                 $property = $definition->property;

--- a/src/ObjectHydratorDumper.php
+++ b/src/ObjectHydratorDumper.php
@@ -140,7 +140,7 @@ CODE;
 
             $collectKeys
 
-            if (\$value === []]) {
+            if (\$value === []) {
                 goto after_$property;
             }
 

--- a/src/ObjectHydratorTest.php
+++ b/src/ObjectHydratorTest.php
@@ -6,6 +6,8 @@ namespace EventSauce\ObjectHydrator;
 
 use EventSauce\ObjectHydrator\Fixtures\ClassThatContainsAnotherClass;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatRenamesInputForClassWithMultipleProperties;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
@@ -195,6 +197,37 @@ class ObjectHydratorTest extends TestCase
 
         self::assertInstanceOf(ClassThatHasMultipleCastersOnSingleProperty::class, $object);
         self::assertEquals('1234', $object->child->name);
+    }
+
+    /**
+     * @test
+     */
+    public function mapping_multiple_keys_to_one_object(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['value' => 'dog', 'name' => 'Rover', 'age' => 2];
+        $object = $hydrator->hydrateObject(ClassThatUsesClassWithMultipleProperties::class, $payload);
+
+        self::assertInstanceOf(ClassThatUsesClassWithMultipleProperties::class, $object);
+        self::assertEquals('dog', $object->value);
+        self::assertEquals('Rover', $object->child->name);
+        self::assertEquals(2, $object->child->age);
+    }
+
+    /**
+     * @test
+     */
+    public function mapping_multiple_keys_to_one_object_with_renames(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['name' => 'Rover', 'mapped_age' => 2];
+        $object = $hydrator->hydrateObject(ClassThatRenamesInputForClassWithMultipleProperties::class, $payload);
+
+        self::assertInstanceOf(ClassThatRenamesInputForClassWithMultipleProperties::class, $object);
+        self::assertEquals('Rover', $object->child->name);
+        self::assertEquals(2, $object->child->age);
     }
 
     protected function createObjectHydrator(): ObjectHydrator

--- a/src/PropertyDefinition.php
+++ b/src/PropertyDefinition.php
@@ -10,11 +10,10 @@ namespace EventSauce\ObjectHydrator;
 class PropertyDefinition
 {
     public function __construct(
-        public string $key,
+        /** @var string[] */
+        public array $keys,
         public string $property,
         public array $propertyCasters,
-//        public ?string $propertyCaster,
-//        public array $castingOptions,
         public bool $canBeHydrated,
         public bool $isEnum,
         public ?string $concreteTypeName,

--- a/src/ReflectionDefinitionProvider.php
+++ b/src/ReflectionDefinitionProvider.php
@@ -33,7 +33,7 @@ class ReflectionDefinitionProvider implements DefinitionProvider
             $parameterType = $this->normalizeType($parameter->getType());
             $definition = [
                 'property' => $paramName,
-                'key' => $paramName,
+                'keys' => [$paramName => $paramName],
                 'enum' => $parameterType->isEnum(),
             ];
 
@@ -42,16 +42,16 @@ class ReflectionDefinitionProvider implements DefinitionProvider
 
             foreach ($attributes as $attribute) {
                 $attributeName = $attribute->getName();
-                $arguments = $attribute->getArguments();
+
                 if ($attributeName === MapFrom::class) {
-                    $definition['key'] = $arguments[0] ?? $definition['key'];
+                    $definition['keys'] = $attribute->newInstance()->keys;
                 } elseif (is_a($attributeName, PropertyCaster::class, true)) {
                     $casters[] = [$attributeName, $attribute->getArguments()];
                 }
             }
 
             $definitions[] = new PropertyDefinition(
-                $definition['key'],
+                $definition['keys'],
                 $definition['property'],
                 $casters,
                 $parameterType->canBeHydrated(),


### PR DESCRIPTION
In some cases multiple properties represent a combined concept that, in code, is represented by a single construct. Similar to [Doctrine's Embeddables](https://www.doctrine-project.org/projects/doctrine-orm/en/2.9/tutorials/embeddables.html), this PR introduces a way to map multiple inputs to a single property.

```php
use EventSauce\ObjectHydrator\MapFrom;

class Person
{
    public function __construct(
        public readonly string $name,
        public readonly int $age,
    ) {}
}

enum MembershipType: string
{
    case PARTICIPANT = 'participant';
    case ORGANIZER = 'organizer';
}

class Membership
{

    public function __construct(
        public readonly Person $person,
        #[MapFrom(['name', 'age'])]
        public readonly MembershipType $type,
    ) {}
}

$membership = $hydrator->hydrateObject(
    Membership::class,
    ['type' => 'participant', 'name' => 'Frank', 'age' => 34]
);
```