### PR TITLE
Add @template info to functions using class-string.

### DIFF
--- a/src/ObjectHydrator.php
+++ b/src/ObjectHydrator.php
@@ -31,6 +31,7 @@ class ObjectHydrator
     }
 
     /**
+     * @template T
      * @param class-string<T> $className
      *
      * @return T
@@ -98,6 +99,7 @@ class ObjectHydrator
     }
 
     /**
+     * @template T
      * @param class-string<T> $className
      * @param iterable<array> $payloads;
      *


### PR DESCRIPTION
When using class-string to check generics with PHAN the @template tag needs to be on the function or it will not be resolved correctly.