### PR TITLE
Added the ability to specify default key conversion strategy

### DIFF
--- a/src/Fixtures/ClassWithCamelCaseProperty.php
+++ b/src/Fixtures/ClassWithCamelCaseProperty.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+final class ClassWithCamelCaseProperty
+{
+    public function __construct(public string $snakeCase)
+    {
+    }
+}

--- a/src/KeyFormatter.php
+++ b/src/KeyFormatter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+interface KeyFormatter
+{
+    public function formatPropertyName(string $propertyName): string;
+}

--- a/src/KeyFormatter.php
+++ b/src/KeyFormatter.php
@@ -6,5 +6,5 @@ namespace EventSauce\ObjectHydrator;
 
 interface KeyFormatter
 {
-    public function formatPropertyName(string $propertyName): string;
+    public function propertyNameToKey(string $propertyName): string;
 }

--- a/src/KeyFormatterForSnakeCasing.php
+++ b/src/KeyFormatterForSnakeCasing.php
@@ -8,7 +8,7 @@ use function strtolower;
 
 class KeyFormatterForSnakeCasing implements KeyFormatter
 {
-    public function formatPropertyName(string $propertyName): string
+    public function propertyNameToKey(string $propertyName): string
     {
         return strtolower(preg_replace('/(.)(?=[A-Z])/u', '$1_', $propertyName));
     }

--- a/src/KeyFormatterForSnakeCasing.php
+++ b/src/KeyFormatterForSnakeCasing.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+use function strtolower;
+
+class KeyFormatterForSnakeCasing implements KeyFormatter
+{
+    public function formatPropertyName(string $propertyName): string
+    {
+        return strtolower(preg_replace('/(.)(?=[A-Z])/u', '$1_', $propertyName));
+    }
+}

--- a/src/KeyFormattingWithoutConversion.php
+++ b/src/KeyFormattingWithoutConversion.php
@@ -6,7 +6,7 @@ namespace EventSauce\ObjectHydrator;
 
 class KeyFormattingWithoutConversion implements KeyFormatter
 {
-    public function formatPropertyName(string $propertyName): string
+    public function propertyNameToKey(string $propertyName): string
     {
         return $propertyName;
     }

--- a/src/KeyFormattingWithoutConversion.php
+++ b/src/KeyFormattingWithoutConversion.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+class KeyFormattingWithoutConversion implements KeyFormatter
+{
+    public function formatPropertyName(string $propertyName): string
+    {
+        return $propertyName;
+    }
+}

--- a/src/ObjectHydratorTest.php
+++ b/src/ObjectHydratorTest.php
@@ -6,8 +6,8 @@ namespace EventSauce\ObjectHydrator;
 
 class ObjectHydratorTest extends ObjectHydratorTestCase
 {
-    protected function createObjectHydrator(): ObjectHydrator
+    protected function createObjectHydrator(DefinitionProvider $definitionProvider = null): ObjectHydrator
     {
-        return new ObjectHydrator();
+        return new ObjectHydrator($definitionProvider);
     }
 }

--- a/src/ObjectHydratorTestCase.php
+++ b/src/ObjectHydratorTestCase.php
@@ -8,6 +8,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassThatContainsAnotherClass;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatRenamesInputForClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesClassWithMultipleProperties;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
@@ -48,7 +49,10 @@ abstract class ObjectHydratorTestCase extends TestCase
         $hydrator = $this->createObjectHydrator();
 
         /** @var ClassWithPropertyMappedFromNestedKey $object */
-        $object = $hydrator->hydrateObject(ClassWithPropertyMappedFromNestedKey::class, ['nested' => ['name' => 'Frank']]);
+        $object = $hydrator->hydrateObject(
+            ClassWithPropertyMappedFromNestedKey::class,
+            ['nested' => ['name' => 'Frank']]
+        );
 
         self::assertInstanceOf(ClassWithPropertyMappedFromNestedKey::class, $object);
         self::assertEquals('Frank', $object->name);
@@ -155,6 +159,21 @@ abstract class ObjectHydratorTestCase extends TestCase
 
         self::assertInstanceOf(ClassWithPropertyThatUsesListCastingToClasses::class, $object);
         self::assertEquals($expectedChildren, $object->children);
+    }
+
+    /**
+     * @test
+     */
+    public function using_default_key_conversion_from_snake_case(): void
+    {
+        $hydrator = $this->createObjectHydrator(
+            new ReflectionDefinitionProvider(null, new KeyFormatterForSnakeCasing())
+        );
+
+        $object = $hydrator->hydrateObject(ClassWithCamelCaseProperty::class, ['snake_case' => 'camelCase']);
+
+        self::assertInstanceOf(ClassWithCamelCaseProperty::class, $object);
+        self::assertEquals('camelCase', $object->snakeCase);
     }
 
     /**
@@ -324,5 +343,5 @@ abstract class ObjectHydratorTestCase extends TestCase
         return $this->createObjectHydrator();
     }
 
-    abstract protected function createObjectHydrator(): ObjectHydrator;
+    abstract protected function createObjectHydrator(DefinitionProvider $definitionProvider = null): ObjectHydrator;
 }

--- a/src/ReflectionDefinitionProvider.php
+++ b/src/ReflectionDefinitionProvider.php
@@ -40,7 +40,7 @@ final class ReflectionDefinitionProvider implements DefinitionProvider
 
         foreach ($parameters as $parameter) {
             $paramName = $parameter->getName();
-            $key = $this->keyFormatter->formatPropertyName($paramName);
+            $key = $this->keyFormatter->propertyNameToKey($paramName);
             $parameterType = $this->normalizeType($parameter->getType());
             $firstTypeName = $parameterType->firstTypeName();
             $definition = [

--- a/src/ReflectionDefinitionProvider.php
+++ b/src/ReflectionDefinitionProvider.php
@@ -15,10 +15,14 @@ use function is_a;
 final class ReflectionDefinitionProvider implements DefinitionProvider
 {
     private DefaultCasterRepository $defaultCasterRepository;
+    private KeyFormatter $keyFormatter;
 
-    public function __construct(DefaultCasterRepository $defaultCasterRepository = null)
-    {
-        $this->defaultCasterRepository = $defaultCasterRepository ?: DefaultCasterRepository::buildIn();
+    public function __construct(
+        DefaultCasterRepository $defaultCasterRepository = null,
+        KeyFormatter $keyFormatter = null,
+    ) {
+        $this->defaultCasterRepository = $defaultCasterRepository ?? DefaultCasterRepository::buildIn();
+        $this->keyFormatter = $keyFormatter ?? new KeyFormattingWithoutConversion();
     }
 
     public function provideDefinition(string $className): ClassDefinition
@@ -36,11 +40,12 @@ final class ReflectionDefinitionProvider implements DefinitionProvider
 
         foreach ($parameters as $parameter) {
             $paramName = $parameter->getName();
+            $key = $this->keyFormatter->formatPropertyName($paramName);
             $parameterType = $this->normalizeType($parameter->getType());
             $firstTypeName = $parameterType->firstTypeName();
             $definition = [
                 'property' => $paramName,
-                'keys' => [$paramName => [$paramName]],
+                'keys' => [$key => [$key]],
                 'enum' => $parameterType->isEnum(),
             ];
 


### PR DESCRIPTION
This pull requests allows a default strategy for property-name to input-data key to be defined. In case your default casing is `snake_case` and your default property naming strategy is `camelCase` this PR will save you a LOT of converting of property names.