### PR TITLE
Add additional CastToDateTimeImmutable attribute argument timezone (optional)

### DIFF
--- a/src/PropertyCasters/CastToDateTimeImmutable.php
+++ b/src/PropertyCasters/CastToDateTimeImmutable.php
@@ -7,6 +7,7 @@ namespace EventSauce\ObjectHydrator\PropertyCasters;
 use Attribute;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use EventSauce\ObjectHydrator\ObjectMapper;
 use EventSauce\ObjectHydrator\PropertyCaster;
 use EventSauce\ObjectHydrator\PropertySerializer;
@@ -16,21 +17,23 @@ use function is_int;
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 final class CastToDateTimeImmutable implements PropertyCaster, PropertySerializer
 {
-    public function __construct(private ?string $format = null)
+    public function __construct(private ?string $format = null, private ?string $timeZone = null)
     {
     }
 
     public function cast(mixed $value, ObjectMapper $hydrator): mixed
     {
+        $timeZone = $this->timeZone ? new DateTimeZone($this->timeZone) : $this->timeZone;
+
         if ($this->format !== null) {
-            return DateTimeImmutable::createFromFormat($this->format, $value);
+            return DateTimeImmutable::createFromFormat($this->format, $value, $timeZone);
         }
 
         if (is_int($value)) {
             $value = "@$value";
         }
 
-        return new DateTimeImmutable($value);
+        return new DateTimeImmutable($value, $timeZone);
     }
 
     public function serialize(mixed $value, ObjectMapper $hydrator): mixed


### PR DESCRIPTION
Moin Moin from Hamburg.

I found your package some weeks ago and bookmarked it. Now is the time I'm using it and I have an optimization suggest for you. The cast `CastToDateTimeImmutable` doesn't care about the date time zone. This can have different side effefcts. In this pull request I added the possibility to use a time zone for the cast.

\- Cheers Jan