### PR TITLE
Type Error when try to hydrate a nullable DateTime(Immutable) Object

### DIFF
--- a/src/Fixtures/ClassWithNullableInput.php
+++ b/src/Fixtures/ClassWithNullableInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use DateTimeImmutable;
+
+final class ClassWithNullableInput
+{
+    public function __construct(
+        public ?DateTimeImmutable $date = null
+    ) {
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -13,7 +13,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
-use EventSauce\ObjectHydrator\Fixtures\ClassWithNotCastedDateTimeInput;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithNullableInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyCasting;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyMappedFromNestedKey;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyThatUsesListCasting;
@@ -29,6 +29,33 @@ use Ramsey\Uuid\UuidInterface;
 
 abstract class ObjectHydrationTestCase extends TestCase
 {
+
+    /**
+     * @test
+     */
+    public function nullable_property_can_be_mapped_with_null_input(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $object = $hydrator->hydrateObject(ClassWithNullableInput::class, ['date' => null]);
+
+        self::assertInstanceOf(ClassWithNullableInput::class, $object);
+        self::assertNull($object->date);
+    }
+
+    /**
+     * @test
+     */
+    public function nullable_property_can_be_mapped_with_real_input(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $object = $hydrator->hydrateObject(ClassWithNullableInput::class, ['date' => '2022-07-01']);
+
+        self::assertInstanceOf(ClassWithNullableInput::class, $object);
+        self::assertInstanceOf(\DateTimeImmutable::class, $object->date);
+    }
+
     /**
      * @test
      */
@@ -237,9 +264,9 @@ abstract class ObjectHydrationTestCase extends TestCase
     {
         $hydrator = $this->createObjectHydrator();
 
-        $object = $hydrator->hydrateObject(ClassWithNotCastedDateTimeInput::class, ['date' => '2022-01-01 12:00:00']);
+        $object = $hydrator->hydrateObject(ClassWithNullableInput::class, ['date' => '2022-01-01 12:00:00']);
 
-        self::assertInstanceOf(ClassWithNotCastedDateTimeInput::class, $object);
+        self::assertInstanceOf(ClassWithNullableInput::class, $object);
         self::assertEquals('2022-01-01 12:00:00', $object->date->format('Y-m-d H:i:s'));
     }
 

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -81,11 +81,13 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
                 $property = $definition->accessorName;
 
-                foreach ($definition->casters as [$caster, $options]) {
-                    $key = $className . json_encode($options);
-                    /** @var PropertyCaster $propertyCaster */
-                    $propertyCaster = $this->casterInstances[$key] ??= new $caster(...$options);
-                    $value = $propertyCaster->cast($value, $this);
+                if ($value !== null) {
+                    foreach ($definition->casters as [$caster, $options]) {
+                        $key = $className . json_encode($options);
+                        /** @var PropertyCaster $propertyCaster */
+                        $propertyCaster = $this->casterInstances[$key] ??= new $caster(...$options);
+                        $value = $propertyCaster->cast($value, $this);
+                    }
                 }
 
                 $typeName = $definition->firstTypeName;
@@ -232,7 +234,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
     }
 
     /**
-     * @param iterable<object> $payloads;
+     * @param iterable<object> $payloads ;
      *
      * @return IterableList<array<mixed>>
      *


### PR DESCRIPTION
*How-To-Reproduce*

checkout commit d1d2c9975ba4a7d40e659377ed622b50e0b06ee6 and execute tests. 
This will cause a Type Error `TypeError: DateTimeImmutable::__construct(): Argument #1 ($datetime) must be of type string, null given`

