### PR TITLE
Fix cache keys colliding when using multiple casters without options

### DIFF
--- a/src/Fixtures/CastToLowerCase.php
+++ b/src/Fixtures/CastToLowerCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use Attribute;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+use function strtolower;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class CastToLowerCase implements PropertyCaster
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        return strtolower((string) $value);
+    }
+}

--- a/src/Fixtures/ClassThatUsesMutipleCastersWithoutOptions.php
+++ b/src/Fixtures/ClassThatUsesMutipleCastersWithoutOptions.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\PropertyCasters\CastToUuid;
+use Ramsey\Uuid\UuidInterface;
+
+#[ExampleData(['id' => '9f960d77-7c9b-4bfd-9fc4-62d141efc7e5', 'name' => 'Joe'])]
+class ClassThatUsesMutipleCastersWithoutOptions
+{
+    public function __construct(
+        #[CastToUuid]
+        public UuidInterface $id,
+        #[CastToLowerCase]
+        public string $name,
+    ) {
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -10,6 +10,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProper
 use EventSauce\ObjectHydrator\Fixtures\ClassThatRenamesInputForClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatTriggersUseStatementLookup;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesClassWithMultipleProperties;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesMutipleCastersWithoutOptions;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValue;
@@ -272,6 +273,24 @@ abstract class ObjectHydrationTestCase extends TestCase
         self::assertInstanceOf(ClassWithFormattedDateTimeInput::class, $object);
         self::assertEquals('1987-11-24 00:00:00', $object->date->format('Y-m-d H:i:s'));
         self::assertEquals('Europe/Amsterdam', $object->date->getTimezone()->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_a_class_with_multiple_casters_without_options(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+        $payload = [
+            'id' => '9f960d77-7c9b-4bfd-9fc4-62d141efc7e5',
+            'name' => 'Joe',
+        ];
+
+        $object = $hydrator->hydrateObject(ClassThatUsesMutipleCastersWithoutOptions::class, $payload);
+
+        self::assertInstanceOf(ClassThatUsesMutipleCastersWithoutOptions::class, $object);
+        self::assertEquals('9f960d77-7c9b-4bfd-9fc4-62d141efc7e5', $object->id->toString());
+        self::assertEquals('joe', $object->name);
     }
 
     /**

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -95,7 +95,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
                 if ($value !== null) {
                     foreach ($definition->casters as [$caster, $options]) {
-                        $key = $className . json_encode($options);
+                        $key = $className . '-' . $caster . '-' . json_encode($options);
                         /** @var PropertyCaster $propertyCaster */
                         $propertyCaster = $this->casterInstances[$key] ??= new $caster(...$options);
                         $value = $propertyCaster->cast($value, $this);


### PR DESCRIPTION
Using multiple casters that have no option within the same class causes the first one to be used for all of them.

Currently, the example below will throw a `UnableToHydrateObject` exception stating "Invalid UUID string: ...".  This is because the cache key is `ClassThatUsesMutipleCastersWithoutOptions[]` for both casters, meaning it will use `CastToUuid` instead of `CastToLowerCase`.

```php
class ClassThatUsesMutipleCastersWithoutOptions
{
    public function __construct(
        #[CastToUuid]
        public UuidInterface $id,

        #[CastToLowerCase]
        public string $name,
    ) {
    }
}
```