### PR TITLE
Fix typo in PHPDoc parser regex pattern

### DIFF
--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -133,7 +133,7 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         $result = (int) preg_match_all(
-            '/\\*\\s+@param\\s+([A-Za-z0-9\\\\\\[\\]<>,]+)\\s\\$([A-Aa-z_0-9]+)/m',
+            '/\\*\\s+@param\\s+([A-Za-z0-9\\\\\\[\\]<>,]+)\\s\\$([A-Za-z_0-9]+)/m',
             $docBlock,
             $matches,
             PREG_SET_ORDER


### PR DESCRIPTION
There's a tiny mistake in the regex pattern used to parse PHPDoc types for arrays. This meant that camelCase properties couldn't be parsed, resulting in "Unable to resolve item type for type" errors.