### PR TITLE
Support nullable enum properties

### DIFF
--- a/src/FixturesFor81/ClassWithNullableEnumProperty.php
+++ b/src/FixturesFor81/ClassWithNullableEnumProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\FixturesFor81;
+
+final class ClassWithNullableEnumProperty
+{
+    public function __construct(
+        public readonly ?CustomEnum $enum,
+    ) {
+    }
+}

--- a/src/FixturesFor81/ClassWithNullableUnitEnumProperty.php
+++ b/src/FixturesFor81/ClassWithNullableUnitEnumProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\FixturesFor81;
+
+final class ClassWithNullableUnitEnumProperty
+{
+    public function __construct(
+        public readonly ?OptionUnitEnum $enum,
+    ) {
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -28,6 +28,8 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithStaticConstructor;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnmappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUuidProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
+use EventSauce\ObjectHydrator\FixturesFor81\ClassWithNullableEnumProperty;
+use EventSauce\ObjectHydrator\FixturesFor81\ClassWithNullableUnitEnumProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\CustomEnum;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -329,6 +331,32 @@ abstract class ObjectHydrationTestCase extends TestCase
         $object = $hydrator->hydrateObject(ClassWithEnumProperty::class, ['enum' => 'one']);
 
         self::assertEquals(CustomEnum::VALUE_ONE, $object->enum);
+    }
+
+    /**
+     * @test
+     * @requires PHP >= 8.1
+     */
+    public function hydrating_an_object_with_a_nullable_enum(): void
+    {
+        $hydrator = $this->createObjectHydratorFor81();
+
+        $object = $hydrator->hydrateObject(ClassWithNullableUnitEnumProperty::class, ['enum' => null]);
+
+        self::assertNull($object->enum);
+    }
+
+    /**
+     * @test
+     * @requires PHP >= 8.1
+     */
+    public function hydrating_an_object_with_a_nullable_backed_enum(): void
+    {
+        $hydrator = $this->createObjectHydratorFor81();
+
+        $object = $hydrator->hydrateObject(ClassWithNullableEnumProperty::class, ['enum' => null]);
+
+        self::assertNull($object->enum);
     }
 
     /**

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -104,9 +104,9 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
                 $typeName = $definition->firstTypeName;
 
-                if ($definition->isBackedEnum()) {
+                if ($definition->isBackedEnum() && $value !== null) {
                     $value = $typeName::from($value);
-                } elseif ($definition->isEnum) {
+                } elseif ($definition->isEnum && $value !== null) {
                     $value = constant("$typeName::$value");
                 } elseif ($definition->canBeHydrated && is_array($value)) {
                     $propertyType = $definition->propertyType;


### PR DESCRIPTION
I have a use case for hydrating objects with nullable enum properties, which is currently not supported. This could also be considered a bug fix since the object mapper otherwise passes `null` to `BackedEnum::from()` (which only accepts `int|string`).

Thanks for your work on this package!