### PR TITLE
Feature: polymorphic object mapping

### DIFF
--- a/src/ClassExpander.php
+++ b/src/ClassExpander.php
@@ -4,18 +4,12 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator;
 
-use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
-use ReflectionClass;
-use Throwable;
 use function array_key_exists;
 use function array_unique;
 use function array_values;
 use function class_exists;
-use function enum_exists;
-use function function_exists;
 use function in_array;
 use function interface_exists;
-use function var_dump;
 
 /**
  * @internal

--- a/src/ClassExpander.php
+++ b/src/ClassExpander.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator;
 
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
 use ReflectionClass;
 use Throwable;
 use function array_key_exists;
+use function array_unique;
 use function array_values;
+use function class_exists;
 use function enum_exists;
 use function function_exists;
 use function in_array;
+use function interface_exists;
+use function var_dump;
 
 /**
  * @internal
@@ -28,7 +33,7 @@ final class ClassExpander
      */
     public static function expandClassesForHydration(array $classes, DefinitionProvider $definitionProvider): array
     {
-        $classes = array_values($classes);
+        $classes = array_unique(array_values($classes));
 
         for ($i = 0; array_key_exists($i, $classes); ++$i) {
             $class = $classes[$i];
@@ -52,17 +57,7 @@ final class ClassExpander
 
     private static function isClass(string $className): bool
     {
-        if (function_exists('enum_exists') && enum_exists($className)) {
-            return false;
-        }
-
-        try {
-            $reflection = new ReflectionClass($className);
-
-            return $reflection->isInstantiable();
-        } catch (Throwable) {
-            return false;
-        }
+        return class_exists($className) || interface_exists($className);
     }
 
     /**

--- a/src/ClassHydrationDefinition.php
+++ b/src/ClassHydrationDefinition.php
@@ -15,6 +15,9 @@ final class ClassHydrationDefinition
     public function __construct(
         public string $constructor,
         public string $constructionStyle,
+        public ?string $typeKey,
+        public array $typeMap,
+        public false|array $mapFrom,
         PropertyHydrationDefinition ...$propertyDefinitions,
     ) {
         $this->propertyDefinitions = $propertyDefinitions;

--- a/src/ClassHydrationDefinition.php
+++ b/src/ClassHydrationDefinition.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator;
 
+use function in_array;
+
 /**
  * @internal
  */
@@ -21,5 +23,10 @@ final class ClassHydrationDefinition
         PropertyHydrationDefinition ...$propertyDefinitions,
     ) {
         $this->propertyDefinitions = $propertyDefinitions;
+    }
+
+    public function canBeConstructed(): bool
+    {
+        return in_array($this->constructionStyle, ['new', 'static']);
     }
 }

--- a/src/ClassSerializationDefinition.php
+++ b/src/ClassSerializationDefinition.php
@@ -13,7 +13,10 @@ class ClassSerializationDefinition
         /**
          * @var PropertySerializationDefinition[]
          */
-        public array $properties
+        public array $properties,
+        public ?string $typeKey,
+        public array $typeMap,
+        public false|array $mapFrom,
     ) {
     }
 }

--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -65,8 +65,17 @@ final class DefinitionProvider
         /** @var PropertyHydrationDefinition[] $definitions */
         $definitions = [];
 
-        $constructionStyle = $constructor instanceof ReflectionMethod ? $constructor->isConstructor() ? 'new' : 'static' : 'new';
-        $constructorName = $constructionStyle === 'new' ? $className : $this->stringifyConstructor($constructor);
+        $constructionStyle = match (true) {
+            $constructor instanceof ReflectionMethod => $constructor->isConstructor() ? 'new' : 'static',
+            ! $reflectionClass->isInstantiable() => 'none',
+            default => 'new',
+        };
+
+        if ($constructionStyle !== 'none') {
+            $constructorName = $constructionStyle === 'new' ? $className : $this->stringifyConstructor($constructor);
+        } else {
+            $constructorName = '';
+        }
 
         /** @var ReflectionParameter[] $parameters */
         $parameters = $constructor instanceof ReflectionMethod ? $constructor->getParameters() : [];

--- a/src/Fixtures/CastersOnClasses/ClassWithClassLevelMapFrom.php
+++ b/src/Fixtures/CastersOnClasses/ClassWithClassLevelMapFrom.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastersOnClasses;
+
+use EventSauce\ObjectHydrator\MapFrom;
+
+#[MapFrom('nested')]
+class ClassWithClassLevelMapFrom
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Fixtures/CastersOnClasses/ClassWithClassLevelMapFromMultiple.php
+++ b/src/Fixtures/CastersOnClasses/ClassWithClassLevelMapFromMultiple.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastersOnClasses;
+
+use EventSauce\ObjectHydrator\MapFrom;
+
+#[MapFrom(['first' => 'one', 'second' => 'two'])]
+class ClassWithClassLevelMapFromMultiple
+{
+    public function __construct(
+        public int $one,
+        public int $two,
+    ) {
+    }
+}

--- a/src/Fixtures/TypeMapping/Animal.php
+++ b/src/Fixtures/TypeMapping/Animal.php
@@ -3,6 +3,15 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
 
+use EventSauce\ObjectHydrator\MapToType;
+
+#[MapToType(
+    key: 'muppet',
+    map: [
+        'rowlf' => Dog::class,
+        'kermit' => Frog::class,
+    ]
+)]
 interface Animal
 {
     public function speak(): string;

--- a/src/Fixtures/TypeMapping/Animal.php
+++ b/src/Fixtures/TypeMapping/Animal.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
+
+interface Animal
+{
+    public function speak(): string;
+}

--- a/src/Fixtures/TypeMapping/Animal.php
+++ b/src/Fixtures/TypeMapping/Animal.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
 
+use EventSauce\ObjectHydrator\MapFrom;
 use EventSauce\ObjectHydrator\MapToType;
 
+#[MapFrom('nested')]
 #[MapToType(
     key: 'muppet',
     map: [

--- a/src/Fixtures/TypeMapping/ClassThatMapsTypes.php
+++ b/src/Fixtures/TypeMapping/ClassThatMapsTypes.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
+
+use EventSauce\ObjectHydrator\MapToType;
+
+class ClassThatMapsTypes
+{
+    public function __construct(
+        #[MapToType('animal', [
+            'frog' => Frog::class,
+            'dog' => Dog::class,
+        ])]
+        public Animal $child
+    ) {
+    }
+}

--- a/src/Fixtures/TypeMapping/Dog.php
+++ b/src/Fixtures/TypeMapping/Dog.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
+
+class Dog implements Animal
+{
+    public function __construct(public string $name)
+    {
+    }
+
+    public function speak(): string
+    {
+        return 'woof';
+    }
+}

--- a/src/Fixtures/TypeMapping/Frog.php
+++ b/src/Fixtures/TypeMapping/Frog.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures\TypeMapping;
+
+class Frog implements Animal
+{
+    public function __construct(public string $color)
+    {
+    }
+
+    public function speak(): string
+    {
+        return 'ribbit';
+    }
+}

--- a/src/MapFrom.php
+++ b/src/MapFrom.php
@@ -8,7 +8,7 @@ use Attribute;
 use function explode;
 use function is_string;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS)]
 final class MapFrom
 {
     /** @var array<string, array<string>> */

--- a/src/MapToType.php
+++ b/src/MapToType.php
@@ -6,7 +6,7 @@ namespace EventSauce\ObjectHydrator;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::TARGET_CLASS | Attribute::IS_REPEATABLE)]
 class MapToType
 {
     public function __construct(

--- a/src/MapToType.php
+++ b/src/MapToType.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class MapToType
+{
+    public function __construct(
+        public string $key = 'type',
+        public array $map = [],
+    ) {
+    }
+}

--- a/src/MapToType.php
+++ b/src/MapToType.php
@@ -11,6 +11,9 @@ class MapToType
 {
     public function __construct(
         public string $key = 'type',
+        /**
+         * @var array<string, class-string>
+         */
         public array $map = [],
     ) {
     }

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator;
 
+use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFrom;
+use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFromMultiple;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToDifferentTypes;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatContainsAnotherClass;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
@@ -52,6 +54,35 @@ abstract class ObjectHydrationTestCase extends TestCase
 
         self::assertInstanceOf(ClassThatMapsTypes::class, $object);
         self::assertInstanceOf(Frog::class, $object->child);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_with_class_level_map_from(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['nested' => ['name' => 'Frank']];
+        $object = $hydrator->hydrateObject(ClassWithClassLevelMapFrom::class, $payload);
+
+        self::assertInstanceOf(ClassWithClassLevelMapFrom::class, $object);
+        self::assertEquals('Frank', $object->name);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_with_class_level_map_from_with_multiple_sources(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['first' => 1, 'second' => 2];
+        $object = $hydrator->hydrateObject(ClassWithClassLevelMapFromMultiple::class, $payload);
+
+        self::assertInstanceOf(ClassWithClassLevelMapFromMultiple::class, $object);
+        self::assertEquals(1, $object->one);
+        self::assertEquals(2, $object->two);
     }
 
     /**

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -27,6 +27,8 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyThatUsesListCastingToCla
 use EventSauce\ObjectHydrator\Fixtures\ClassWithStaticConstructor;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnmappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUuidProperty;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Frog;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumPropertyWithDefault;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithNullableEnumProperty;
@@ -38,6 +40,20 @@ use Ramsey\Uuid\UuidInterface;
 
 abstract class ObjectHydrationTestCase extends TestCase
 {
+    /**
+     * @test
+     */
+    public function hydrating_a_polymorphic_property(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['child' => ['animal' => 'frog', 'color' => 'blue']];
+        $object = $hydrator->hydrateObject(ClassThatMapsTypes::class, $payload);
+
+        self::assertInstanceOf(ClassThatMapsTypes::class, $object);
+        self::assertInstanceOf(Frog::class, $object->child);
+    }
+
     /**
      * @test
      */

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -63,7 +63,7 @@ abstract class ObjectHydrationTestCase extends TestCase
     {
         $hydrator = $this->createObjectHydrator();
 
-        $payload = ['muppet' => 'kermit', 'color' => 'blue'];
+        $payload = ['nested' => ['muppet' => 'kermit', 'color' => 'blue']];
         $object = $hydrator->hydrateObject(Animal::class, $payload);
 
         self::assertInstanceOf(Animal::class, $object);

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -29,6 +29,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyThatUsesListCastingToCla
 use EventSauce\ObjectHydrator\Fixtures\ClassWithStaticConstructor;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnmappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUuidProperty;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Frog;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
@@ -54,6 +55,20 @@ abstract class ObjectHydrationTestCase extends TestCase
 
         self::assertInstanceOf(ClassThatMapsTypes::class, $object);
         self::assertInstanceOf(Frog::class, $object->child);
+    }
+    /**
+     * @test
+     */
+    public function hydrating_a_polymorphic_interface(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $payload = ['muppet' => 'kermit', 'color' => 'blue'];
+        $object = $hydrator->hydrateObject(Animal::class, $payload);
+
+        self::assertInstanceOf(Animal::class, $object);
+        self::assertInstanceOf(Frog::class, $object);
+        self::assertEquals('blue', $object->color);
     }
 
     /**

--- a/src/ObjectMapper.php
+++ b/src/ObjectMapper.php
@@ -36,6 +36,14 @@ interface ObjectMapper
     public function serializeObject(object $object): mixed;
 
     /**
+     * @template T
+     *
+     * @param T               $object
+     * @param class-string<T> $className
+     */
+    public function serializeObjectOfType(object $object, string $className): mixed;
+
+    /**
      * @param iterable<object> $payloads
      *
      * @return IterableList<array<mixed>>

--- a/src/ObjectMapperCodeGenerator.php
+++ b/src/ObjectMapperCodeGenerator.php
@@ -35,7 +35,7 @@ final class ObjectMapperCodeGenerator
 
         foreach ($hydrationClasses as $className) {
             $classDefinition = $this->definitionProvider->provideHydrationDefinition($className);
-            $methodName = 'hydrate' . str_replace('\\', '⚡', $className);
+            $methodName = 'hydrate' . str_replace('\\', '⚡️', $className);
             $hydratorMap[] = "'$className' => \$this->$methodName(\$payload),";
             $hydrators[] = $this->dumpClassHydrator($className, $classDefinition);
         }
@@ -328,7 +328,7 @@ CODE;
                     $typeMatchMapCode = '';
 
                     foreach ($definition->typeMap as $payloadType => $valueType) {
-                        $methodName = 'hydrate' . str_replace('\\', '', $valueType);
+                        $methodName = 'hydrate' . str_replace('\\', '⚡️', $valueType);
                         $typeMatchMapCode .= <<<CODE
                     '$payloadType' => \$this->$methodName(\$value),
 
@@ -381,7 +381,7 @@ CODE;
 CODE;
         }
 
-        $methodName = 'hydrate' . str_replace('\\', '⚡', $className);
+        $methodName = 'hydrate' . str_replace('\\', '⚡️', $className);
 
         if ($classDefinition->canBeConstructed() === false) {
             if ($classDefinition->typeKey === null) {
@@ -399,7 +399,7 @@ CODE;
             $typeMatchMapCode = '';
 
             foreach ($classDefinition->typeMap as $payloadType => $valueType) {
-                $method = 'hydrate' . str_replace('\\', '', $valueType);
+                $method = 'hydrate' . str_replace('\\', '⚡️', $valueType);
                 $typeMatchMapCode .= <<<CODE
                  '$payloadType' => \$this->$method(\$payload),
 
@@ -478,14 +478,14 @@ CODE;
 
     private function dumpClassSerializer(string $class, ClassSerializationDefinition $definition): string
     {
-        $methodName = 'serializeObject' . str_replace('\\', '⚡', $class);
+        $methodName = 'serializeObject' . str_replace('\\', '⚡️', $class);
         $typeMapCode = '';
         $propertiesCode = '';
 
         if ($definition->typeKey) {
             $map = [];
             foreach ($definition->typeMap as $p => $v) {
-                $map[$p] = [$v, 'serializeObject' . str_replace('\\', '', $v)];
+                $map[$p] = [$v, 'serializeObject' . str_replace('\\', '⚡️', $v)];
             }
             $typeMapExported = var_export($map, true);
             $typeMapCode = <<<CODE
@@ -560,7 +560,7 @@ CODE;
         $matchCode = '';
 
         foreach ($definition->typeMap as $payloadType => $valueType) {
-            $methodName = 'serializeObject' . str_replace('\\', '', $valueType);
+            $methodName = 'serializeObject' . str_replace('\\', '⚡️', $valueType);
             $matchCode .= <<<CODE
             is_a(\$$definition->accessorName, '$valueType') => ['$definition->typeSpecifier' => '$payloadType'] + \$this->$methodName(\$$definition->accessorName),
 

--- a/src/ObjectMapperCodeGeneratorHydrationTest.php
+++ b/src/ObjectMapperCodeGeneratorHydrationTest.php
@@ -6,10 +6,12 @@ namespace EventSauce\ObjectHydrator;
 
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use League\ConstructFinder\ConstructFinder;
+use function array_unique;
 use function class_exists;
 use function spl_object_hash;
 use function strpos;
 use function unlink;
+use function var_dump;
 
 class ObjectMapperCodeGeneratorHydrationTest extends ObjectHydrationTestCase
 {
@@ -44,17 +46,18 @@ class ObjectMapperCodeGeneratorHydrationTest extends ObjectHydrationTestCase
         }
 
         $classes = ConstructFinder::locatedIn($directory)->findClassNames();
+        $interfaces = ConstructFinder::locatedIn($directory)->findInterfaceNames();
         $dumper = new ObjectMapperCodeGenerator($definitionProvider);
 
         $dumpedDefinition = $dumper->dump(
-            $classes,
+            array_unique([...$interfaces, ...$classes]),
             $className
         );
         $filename = __DIR__ . '/test' . (strpos($directory, '81') === false ? '80' : '81') . '.php';
 
         file_put_contents($filename, $dumpedDefinition);
         include $filename;
-        unlink($filename);
+//        unlink($filename);
 
         create_object_hydrator:
         /** @var ObjectMapper $objectHydrator */

--- a/src/ObjectMapperCodeGeneratorHydrationTest.php
+++ b/src/ObjectMapperCodeGeneratorHydrationTest.php
@@ -11,7 +11,6 @@ use function class_exists;
 use function spl_object_hash;
 use function strpos;
 use function unlink;
-use function var_dump;
 
 class ObjectMapperCodeGeneratorHydrationTest extends ObjectHydrationTestCase
 {
@@ -57,7 +56,7 @@ class ObjectMapperCodeGeneratorHydrationTest extends ObjectHydrationTestCase
 
         file_put_contents($filename, $dumpedDefinition);
         include $filename;
-//        unlink($filename);
+        unlink($filename);
 
         create_object_hydrator:
         /** @var ObjectMapper $objectHydrator */

--- a/src/ObjectMapperCodeGeneratorSerializationTest.php
+++ b/src/ObjectMapperCodeGeneratorSerializationTest.php
@@ -44,10 +44,11 @@ class ObjectMapperCodeGeneratorSerializationTest extends ObjectSerializationTest
         }
 
         $classes = ConstructFinder::locatedIn($directory)->findClassNames();
+        $interfaces = ConstructFinder::locatedIn($directory)->findInterfaceNames();
         $dumper = new ObjectMapperCodeGenerator($definitionProvider);
 
         $dumpedDefinition = $dumper->dump(
-            $classes,
+            [...$classes, ...$interfaces],
             $className
         );
         $filename = __DIR__ . '/test' . (strpos($directory, '81') === false ? '80' : '81') . '.php';
@@ -71,12 +72,12 @@ class ObjectMapperCodeGeneratorSerializationTest extends ObjectSerializationTest
         return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', $className, $definitionProvider);
     }
 
-    public function objectHydrator(): ObjectMapper
+    public function objectMapper(): ObjectMapper
     {
         return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', 'AcmeCorp\\DumpedHydrator', $this->defaultDefinitionProvider);
     }
 
-    protected function objectHydratorFor81(): ObjectMapper
+    protected function objectMapperFor81(): ObjectMapper
     {
         return $this->createDumpedObjectHydrator(__DIR__ . '/FixturesFor81', 'AcmeCorp\\DumpedHydratorFor81', $this->defaultDefinitionProvider);
     }

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -23,7 +23,6 @@ use function is_a;
 use function is_array;
 use function is_object;
 use function json_encode;
-use function var_dump;
 
 class ObjectMapperUsingReflection implements ObjectMapper
 {

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -220,7 +220,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
                         $result = $this->serializeObjectOfType($object, $valueType);
                         $result[$definition->typeKey] = $payloadType;
 
-                        return $result;
+                        goto process_map_from;
                     }
                 }
 
@@ -285,6 +285,14 @@ class ObjectMapperUsingReflection implements ObjectMapper
                 }
 
                 $this->assignToResult($keys, $result, $value);
+            }
+
+            process_map_from:
+            if ($mapFrom = $definition->mapFrom) {
+                $r = [];
+                $this->assignToResult($mapFrom, $r, $result);
+
+                return $r;
             }
 
             return $result;

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -117,7 +117,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     $value = $propertyCaster->cast($value, $this);
                 }
 
-                if ($definition->typeAccessor && is_array($value)) {
+                if ($definition->typeKey && is_array($value)) {
                     $value = $this->hydrateViaTypeMap($definition, $value);
                 }
 
@@ -339,7 +339,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
     private function hydrateViaTypeMap(PropertyHydrationDefinition|ClassHydrationDefinition $definition, array $payload): object
     {
-        $type = $payload[$definition->typeAccessor ?? ''] ?? '';
+        $type = $payload[$definition->typeKey ?? ''] ?? '';
         $valueType = $definition->typeMap[$type] ?? null;
 
         if ($valueType === null) {

--- a/src/ObjectMapperUsingReflectionSerializationTest.php
+++ b/src/ObjectMapperUsingReflectionSerializationTest.php
@@ -6,13 +6,13 @@ namespace EventSauce\ObjectHydrator;
 
 class ObjectMapperUsingReflectionSerializationTest extends ObjectSerializationTestCase
 {
-    public function objectHydrator(): ObjectMapper
+    public function objectMapper(): ObjectMapper
     {
         return new ObjectMapperUsingReflection();
     }
 
-    protected function objectHydratorFor81(): ObjectMapper
+    protected function objectMapperFor81(): ObjectMapper
     {
-        return $this->objectHydrator();
+        return $this->objectMapper();
     }
 }

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -7,6 +7,7 @@ namespace EventSauce\ObjectHydrator;
 use DateTime;
 use DateTimeImmutable;
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFrom;
+use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFromMultiple;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionOne;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionTwo;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatOmitsPublicMethods;
@@ -70,13 +71,25 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_a_class_with_class_level_map_from(): void
     {
-        self::markTestSkipped('nope');
         $serializer = $this->objectMapper();
 
         $object = new ClassWithClassLevelMapFrom('Rover');
         $payload = $serializer->serializeObject($object);
 
         self::assertEquals(['nested' => ['name' => 'Rover']], $payload);
+    }
+
+    /**
+     * @test
+     */
+    public function serializing_a_class_with_multiple_class_level_map_from(): void
+    {
+        $serializer = $this->objectMapper();
+
+        $object = new ClassWithClassLevelMapFromMultiple(2, 4);
+        $payload = $serializer->serializeObject($object);
+
+        self::assertEquals(['first' => 2, 'second' => 4], $payload);
     }
 
     /**

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -112,7 +112,7 @@ abstract class ObjectSerializationTestCase extends TestCase
     {
         $object = new ClassThatOmitsPublicMethods();
 
-        $payload = $this->objectHydrator()->serializeObject($object);
+        $payload = $this->objectMapper()->serializeObject($object);
 
         assertEquals(1, count(array_keys($payload)));
         assertEquals(['included' => 'included!'], $payload);
@@ -125,7 +125,7 @@ abstract class ObjectSerializationTestCase extends TestCase
     {
         $object = new ClassThatOmitsPublicProperties();
 
-        $payload = $this->objectHydrator()->serializeObject($object);
+        $payload = $this->objectMapper()->serializeObject($object);
 
         assertEquals(1, count(array_keys($payload)));
         assertEquals(['included' => 'included!'], $payload);
@@ -138,7 +138,7 @@ abstract class ObjectSerializationTestCase extends TestCase
     {
         $object = new ClassThatOmitsSpecificMethodsAndProperties();
 
-        $payload = $this->objectHydrator()->serializeObject($object);
+        $payload = $this->objectMapper()->serializeObject($object);
 
         assertEquals(2, count(array_keys($payload)));
         assertEquals([

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -62,8 +62,8 @@ abstract class ObjectSerializationTestCase extends TestCase
         /** @var array $payload */
         $payload = $serializer->serializeObjectOfType($object, Animal::class);
         self::assertIsArray($payload);
-        self::assertEquals('rowlf', $payload['muppet'] ?? '');
-        self::assertEquals('Rover', $payload['name'] ?? '');
+        self::assertEquals('rowlf', $payload['nested']['muppet'] ?? '');
+        self::assertEquals('Rover', $payload['nested']['name'] ?? '');
     }
 
     /**

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -19,6 +19,8 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithListOfObjects;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnionProperty;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Dog;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\CustomEnum;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +32,21 @@ abstract class ObjectSerializationTestCase extends TestCase
     abstract public function objectHydrator(): ObjectMapper;
 
     abstract protected function objectHydratorFor81(): ObjectMapper;
+
+    /**
+     * @test
+     */
+    public function serializing_a_class_with_polymorphism(): void
+    {
+        $serializer = $this->objectHydrator();
+        $object = new ClassThatMapsTypes(new Dog('Rover'));
+
+        /** @var array $payload */
+        $payload = $serializer->serializeObject($object);
+        self::assertIsArray($payload);
+        self::assertEquals('dog', $payload['child']['animal'] ?? '');
+        self::assertEquals('Rover', $payload['child']['name'] ?? '');
+    }
 
     /**
      * @test

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -6,6 +6,7 @@ namespace EventSauce\ObjectHydrator;
 
 use DateTime;
 use DateTimeImmutable;
+use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFrom;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionOne;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionTwo;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatOmitsPublicMethods;
@@ -19,6 +20,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithListOfObjects;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnionProperty;
+use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Dog;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
@@ -29,16 +31,16 @@ use function PHPUnit\Framework\assertEquals;
 
 abstract class ObjectSerializationTestCase extends TestCase
 {
-    abstract public function objectHydrator(): ObjectMapper;
+    abstract public function objectMapper(): ObjectMapper;
 
-    abstract protected function objectHydratorFor81(): ObjectMapper;
+    abstract protected function objectMapperFor81(): ObjectMapper;
 
     /**
      * @test
      */
     public function serializing_a_class_with_polymorphism(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassThatMapsTypes(new Dog('Rover'));
 
         /** @var array $payload */
@@ -51,9 +53,38 @@ abstract class ObjectSerializationTestCase extends TestCase
     /**
      * @test
      */
+    public function serializing_an_interface_with_polymorphism(): void
+    {
+        $serializer = $this->objectMapper();
+        $object = new Dog('Rover');
+
+        /** @var array $payload */
+        $payload = $serializer->serializeObjectOfType($object, Animal::class);
+        self::assertIsArray($payload);
+        self::assertEquals('rowlf', $payload['muppet'] ?? '');
+        self::assertEquals('Rover', $payload['name'] ?? '');
+    }
+
+    /**
+     * @test
+     */
+    public function serializing_a_class_with_class_level_map_from(): void
+    {
+        self::markTestSkipped('nope');
+        $serializer = $this->objectMapper();
+
+        $object = new ClassWithClassLevelMapFrom('Rover');
+        $payload = $serializer->serializeObject($object);
+
+        self::assertEquals(['nested' => ['name' => 'Rover']], $payload);
+    }
+
+    /**
+     * @test
+     */
     public function serializing_an_object_with_a_public_property(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassWithCamelCaseProperty('some_property');
 
         $payload = $serializer->serializeObject($object);
@@ -108,7 +139,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_an_object_with_a_public_method(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassWithCamelCasePublicMethod('some_property');
 
         $payload = $serializer->serializeObject($object);
@@ -121,7 +152,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_a_list_of_custom_objects(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassWithListOfObjects([
             new ClassWithCamelCasePublicMethod('first_element'),
             new ClassWithCamelCasePublicMethod('second_element'),
@@ -140,7 +171,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_a_list_of_internal_objects(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $now = new DateTimeImmutable();
         $nowFormatted = $now->format('Y-m-d H:i:s.uO');
         $object = new ClassWithListOfObjects([$now]);
@@ -155,7 +186,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_using_custom_date_time_formats(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassWithCustomDateTimeSerialization(
             promotedPublicProperty: DateTimeImmutable::createFromFormat('!Y-m-d', '1987-11-24'),
             regularPublicProperty: DateTimeImmutable::createFromFormat('!Y-m-d', '1987-11-25'),
@@ -177,7 +208,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_a_class_with_an_enum(): void
     {
-        $serializer = $this->objectHydratorFor81();
+        $serializer = $this->objectMapperFor81();
         $object = new ClassWithEnumProperty(CustomEnum::VALUE_ONE);
 
         $payload = $serializer->serializeObject($object);
@@ -190,7 +221,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function serializing_a_class_with_a_union(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object1 = new ClassWithUnionProperty(
             new ClassReferencedByUnionOne(1234),
             'name',
@@ -230,7 +261,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function mapping_to_a_different_key(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassWithMappedStringProperty(name: 'Frank');
 
         $payload = $serializer->serializeObject($object);
@@ -242,7 +273,7 @@ abstract class ObjectSerializationTestCase extends TestCase
      */
     public function mapping_to_multiple_keys(): void
     {
-        $serializer = $this->objectHydrator();
+        $serializer = $this->objectMapper();
         $object = new ClassThatRenamesInputForClassWithMultipleProperties(
             new ClassWithMultipleProperties(age: 34, name: 'Frank')
         );

--- a/src/PropertyHydrationDefinition.php
+++ b/src/PropertyHydrationDefinition.php
@@ -20,7 +20,7 @@ final class PropertyHydrationDefinition
         public bool $nullable,
         public bool $hasDefaultValue,
         public ?string $firstTypeName,
-        public ?string $typeAccessor,
+        public ?string $typeKey,
         public array $typeMap = [],
     ) {
     }

--- a/src/PropertyHydrationDefinition.php
+++ b/src/PropertyHydrationDefinition.php
@@ -20,6 +20,8 @@ final class PropertyHydrationDefinition
         public bool $nullable,
         public bool $hasDefaultValue,
         public ?string $firstTypeName,
+        public ?string $typeAccessor,
+        public array $typeMap = [],
     ) {
     }
 

--- a/src/PropertySerializationDefinition.php
+++ b/src/PropertySerializationDefinition.php
@@ -18,6 +18,8 @@ class PropertySerializationDefinition
         public PropertyType $propertyType,
         public bool $nullable,
         public array $keys = [],
+        public ?string $typeSpecifier = null,
+        public array $typeMap = [],
     ) {
         $this->serializers = array_filter($this->serializers);
     }

--- a/src/UnableToHydrateObject.php
+++ b/src/UnableToHydrateObject.php
@@ -53,4 +53,9 @@ final class UnableToHydrateObject extends RuntimeException
     {
         return new static("Unable to hydrate object: $className, no hydrator defined", stack: $stack);
     }
+
+    public static function classIsNotInstantiable(string $className, array $stack = []): static
+    {
+        return new static("Unable to hydrate object: $className, is not instantiable", stack: $stack);
+    }
 }


### PR DESCRIPTION
EDIT: This PR now contains class-level MapFrom and MapToType

This PR makes it possible to hydrate and serialise polymorphic structures using an #[attribute].

Given the following classes:

```php
use EventSauce\ObjectHydrator\MapToType;

class ClassThatMapsTypes
{
    public function __construct(
        #[MapToType('animal', [
            'frog' => Frog::class,
            'dog' => Dog::class,
        ])]
        public Animal $child
    ) {
    }
}

class Dog implements Animal
{
    public function __construct(public string $name)
    {
    }

    public function speak(): string
    {
        return 'woof';
    }
}

class Frog implements Animal
{
    public function __construct(public string $color)
    {
    }

    public function speak(): string
    {
        return 'ribbit';
    }
}
```

When deserialising a payload:

```php

$object = $objectMapper->hydrateObject(ClassThatMapsTypes::class, [
   'child' => ['animal' => 'dog', 'name' => 'Rover'],
];

assert($object->child instanceof Dog);
assert($object->child->name === 'Rover');