### PR TITLE
Support PHPDocs with non-array `@param` types

### DIFF
--- a/src/Fixtures/ClassThatCastsListsToBasedOnDocComments.php
+++ b/src/Fixtures/ClassThatCastsListsToBasedOnDocComments.php
@@ -9,11 +9,13 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty as CamelClass;
 class ClassThatCastsListsToBasedOnDocComments
 {
     /**
+     * @param int                       $number
      * @param CamelClass[]              $list
      * @param array<string, CamelClass> $map
      * @param array<CamelClass>         $map
      */
     public function __construct(
+        public int $number,
         public array $list,
         public array $map,
         public array $array,

--- a/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
@@ -38,6 +38,7 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
         yield 'class with list type resolve from doc comment' => [
             ClassThatCastsListsToBasedOnDocComments::class,
             [
+                'number' => 1,
                 'list' => [
                     ['snake_case' => 'Frank'],
                     ['snake_case' => 'Renske'],

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -183,6 +183,10 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
             return substr($type, 0, -2);
         }
 
+        if (in_array($type, ['null', 'bool', 'int', 'float', 'string', 'array'])) {
+            return $type;
+        }
+
         if (preg_match('/array<(?:(int(?:eger)?|string|mixed),\\s*)?([A-Za-z0-9\\\\]+)>/', $type, $matches)) {
             return $matches[2];
         }

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -133,7 +133,7 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         $result = (int) preg_match_all(
-            '/\\*\\s+@param\\s+([A-Za-z0-9\\\\\\[\\]<>,]+)\\s\\$([A-Za-z_0-9]+)/m',
+            '/\\*\\s+@param\\s+([A-Za-z0-9\\\\\\[\\]<>,]+)\\s+\\$([A-Za-z_0-9]+)/m',
             $docBlock,
             $matches,
             PREG_SET_ORDER


### PR DESCRIPTION
_This PR contains only failing tests and a partial fix, because I'm unsure how to implement the correct fix. I figured a PR with failing tests would be more helpful than just an issue._

When ObjectHydrator tries to resolve array types from PHPDocs when hydrating objects, it breaks when the PHPDoc contains additional `@param` tags for non-array types, specifically when there's a single space after the non-array type. This PHPDoc currently breaks:

```php
/**
 * @param int $number
 * @param CamelClass[] $list
 */
public function __construct(
    public int $number,
    public array $list,
) {}

// LogicException : Unable to resolve item type for type: int
```

The issue is partly related to this regex: https://github.com/EventSaucePHP/ObjectHydrator/blob/main/src/NaivePropertyTypeResolver.php#LL136. It doesn't match PHPDocs with more than one space after the `@param` type, which may be why this issue hasn't come up before.

I'm not sure what the right fix would be. Ideally we should avoid passing the matched type to [`extractItemType()`](https://github.com/EventSaucePHP/ObjectHydrator/blob/main/src/NaivePropertyTypeResolver.php#L180), but that would complicate the regex. Alternatively, we could do an early return from `extractItemType()` without throwing an exception, and return false from [`resolveFromConstructorDocComment()`](https://github.com/EventSaucePHP/ObjectHydrator/blob/main/src/NaivePropertyTypeResolver.php#L122-L178).

I'd like to hear your thoughts. I'm open to implementing a fix if you could provide some guidance.

Thanks for your time and effort!