### PR TITLE
Add mixed as native type in NaivePropertyTypeResolver

### DIFF
--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -148,7 +148,7 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         foreach ($matches as [, $type, $paramName]) {
             $type = $this->extractItemType(trim($type));
 
-            if (str_starts_with($type, '\\') || in_array($type, ['bool', 'boolean', 'int', 'integer', 'float', 'double', 'string', 'array', 'object', 'null'])) {
+            if (str_starts_with($type, '\\') || in_array($type, ['bool', 'boolean', 'int', 'integer', 'float', 'double', 'string', 'array', 'object', 'null', 'mixed'])) {
                 continue;
             }
 


### PR DESCRIPTION
I ran across a situation where having a `@param array<mixed>` makes NaivePropertyTypeResolver crash on trying to resolve it as a class.