### PR TITLE
serialization: skippable fields

### DIFF
--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -29,17 +29,21 @@ final class DefinitionProvider
 
     private PropertyTypeResolver $propertyTypeResolver;
 
+    private SkippableTypesRepository $skippableTypesRepository;
+
     public function __construct(
         DefaultCasterRepository     $defaultCasterRepository = null,
         KeyFormatter                $keyFormatter = null,
         DefaultSerializerRepository $defaultSerializerRepository = null,
         PropertyTypeResolver        $propertyTypeResolver = null,
+        SkippableTypesRepository    $skippableTypesRepository = null,
     )
     {
         $this->defaultCasters = $defaultCasterRepository ?? DefaultCasterRepository::builtIn();
         $this->keyFormatter = $keyFormatter ?? new KeyFormatterForSnakeCasing();
         $this->defaultSerializers = $defaultSerializerRepository ?? DefaultSerializerRepository::builtIn();
         $this->propertyTypeResolver = $propertyTypeResolver ?? new NaivePropertyTypeResolver();
+        $this->skippableTypesRepository = $skippableTypesRepository ?? SkippableTypesRepository::createDefault();
     }
 
     /**
@@ -149,6 +153,11 @@ final class DefinitionProvider
         }
 
         return $reflectionClass->getConstructor();
+    }
+
+    public function isValueTypeSkippable(object $value): bool
+    {
+        return $this->skippableTypesRepository->hasType($value::class);
     }
 
     private function stringifyConstructor(ReflectionMethod $constructor): string

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -275,7 +275,9 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
                 assign_result:
 
-                if ($value instanceof BackedEnum) {
+                if ($value instanceof Skippable) {
+                    continue;
+                } else if ($value instanceof BackedEnum) {
                     $value = $value->value;
                 } elseif ($value instanceof UnitEnum) {
                     $value = $value->name;

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -275,9 +275,9 @@ class ObjectMapperUsingReflection implements ObjectMapper
 
                 assign_result:
 
-                if ($value instanceof Skippable) {
+                if (is_object($value) && $this->definitionProvider->isValueTypeSkippable($value)) {
                     continue;
-                } else if ($value instanceof BackedEnum) {
+                } elseif ($value instanceof BackedEnum) {
                     $value = $value->value;
                 } elseif ($value instanceof UnitEnum) {
                     $value = $value->name;

--- a/src/Skippable.php
+++ b/src/Skippable.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+class Skippable
+{
+    public static function skip(): Skippable
+    {
+        return new self();
+    }
+}

--- a/src/SkippableTypesRepository.php
+++ b/src/SkippableTypesRepository.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace EventSauce\ObjectHydrator;
+
+class SkippableTypesRepository
+{
+    public function __construct(
+        private array $types
+    ) { }
+
+    public static function createDefault(): SkippableTypesRepository
+    {
+        return new self([Skippable::class => true]);
+    }
+
+    /**
+     * @param class-string $classname
+     */
+    public function addType(string $classname): static
+    {
+        $this->types[$classname] = true;
+
+        return $this;
+    }
+
+    public function removeType($classname): static
+    {
+        if (isset($this->types[$classname])) {
+            unset($this->types[$classname]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param class-string $classname
+     */
+    public function hasType(string $classname): bool
+    {
+        return isset($this->types[$classname]);
+    }
+}


### PR DESCRIPTION
I use this library in my projects and sometimes, when i use it for DTO with http-based repositories, i realy miss functional to skip serialization for some fields.
For example, we have object with 1 required field and 2 nullable. I want to serialize it to array with required and one nullable field. I cant do that, because this library creates object through constructor, so field can't be undefined, and null serializes as null. 
My suggestion for a solution to this problem: add a special class (Skippable, for example), which, when seen as value type, would make the serializer know to just skip it.

Code example

```php
class Order {
    public function __construct(
        public int  $id,
        public null|string|Skippable $number = null,
        public null|Skippable|string $description = null
    ) { }
}

$mapper = new ObjectMapperUsingReflection();
$order = new Order(123, Skippable::skip(), null);

$serialized = $mapper->serializeObject($order);

var_dump($serialized);
```

Ouptut is:

`
array(2) {
  ["id"]=>
  int(123)
  ["description"]=>
  NULL
}
`