### PR TITLE
Fix exception when docblock comment has array following scalar

### DIFF
--- a/src/Fixtures/ClassWithDocblockAndArrayFollowingScalar.php
+++ b/src/Fixtures/ClassWithDocblockAndArrayFollowingScalar.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+class ClassWithDocblockAndArrayFollowingScalar
+{
+    /**
+     * Constructor.
+     *
+     * @param string $test
+     *   Param name.
+     * @param string[] $test2
+     *   Param 2 name.
+     */
+    public function __construct(
+        public readonly string $test,
+        protected array $test2,
+    ) {
+    }
+}

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -144,8 +144,12 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         $commentTypeMap = [];
+        $parameterType = NULL;
 
         foreach ($matches as [, $type, $paramName]) {
+            if ($paramName !== $parameter->name) {
+                continue;
+            }
             $type = $this->extractItemType(trim($type));
 
             if (str_starts_with($type, '\\') || in_array($type, ['bool', 'boolean', 'int', 'integer', 'float', 'double', 'string', 'array', 'object', 'null', 'mixed'])) {
@@ -160,17 +164,16 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
             }
 
             if (array_key_exists($base, $useMap)) {
-                $commentTypeMap[$paramName] = $useMap[$base];
+                $parameterType = $useMap[$base];
             } else {
-                $commentTypeMap[$paramName] = ltrim($namespace . '\\' . $base, '\\');
+                $parameterType = ltrim($namespace . '\\' . $base, '\\');
             }
         }
 
-        if ( ! array_key_exists($parameter->name, $commentTypeMap)) {
+        if ( ! $parameterType) {
             return false;
         }
 
-        $parameterType = $commentTypeMap[$parameter->name];
         $reflectionClass = new ReflectionClass($parameterType);
 
         return PropertyType::collectionContaining($reflectionClass);

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -15,6 +15,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesMutipleCastersWithoutOptions;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockAndArrayFollowingScalar;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValue;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
@@ -586,6 +587,21 @@ abstract class ObjectHydrationTestCase extends TestCase
         $object = $hydrator->hydrateObject(ClassThatTriggersUseStatementLookup::class, $payload);
 
         self::assertInstanceOf(ClassThatTriggersUseStatementLookup::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_a_class_with_valid_docblock_array_following_scalar(): void {
+        $hydrator = $this->createObjectHydrator();
+        $payload = [
+            'test' => 'Brad',
+            'test2' => ['Gianna', 'Kate'],
+        ];
+
+        $object = $hydrator->hydrateObject(ClassWithDocblockAndArrayFollowingScalar::class, $payload);
+
+        self::assertInstanceOf(ClassWithDocblockAndArrayFollowingScalar::class, $object);
     }
 
     protected function createObjectHydratorFor81(): ObjectMapper


### PR DESCRIPTION
When a constructor has a docblock and an array parameter follows a scalar, the parameter resolver chokes while iterating through non-array options. I think this reveals a hole in test coverage. Added a fix (which should also be a very slight performance improvement) and test coverage.

Test-only symptom:

```
EventSauce\ObjectHydrator\UnableToHydrateObject: Unable to hydrate object: EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockAndArrayFollowingScalar
Caused by: Unable to resolve item type for type: string
```