### PR TITLE
Improve support for docblocks and FQCNs

### DIFF
--- a/src/Fixtures/ClassWithDocblockArrayVariants.php
+++ b/src/Fixtures/ClassWithDocblockArrayVariants.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+class ClassWithDocblockArrayVariants
+{
+    /**
+     * Constructor.
+     *
+     * @param array[] $test
+     *   Param name.
+     * @param string[] $test2
+     *   Param 2 name.
+     * @param array<string> $test3
+     *   Param 3 name.
+     * @param array<string, int> $test4
+     *   Param 4 name.
+     * @param array $test5
+     *   Param 5 name.
+     * @param \EventSauce\ObjectHydrator\Fixtures\ClassWithNullableProperty[] $test6
+     *   Param 6 name.
+     * @param EventSauce\ObjectHydrator\Fixtures\ClassWithNullableProperty[] $test7
+     *   Param 7 name.
+     * @param ClassWithNullableProperty[] $test8
+     *   Param 8 name.
+     * @param array<\EventSauce\ObjectHydrator\Fixtures\ClassWithNullableProperty> $test9
+     *   Param 9 name.
+     * @param array<int, \EventSauce\ObjectHydrator\Fixtures\ClassWithNullableProperty> $test10
+     *   Param 10 name.
+     */
+    public function __construct(
+        public array $test,
+        public array $test2,
+        public array $test3,
+        public array $test4,
+        public array $test5,
+        public array $test6,
+        public array $test7,
+        public array $test8,
+        public array $test9,
+        public array $test10,
+    ) {
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -17,6 +17,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockAndArrayFollowingScalar;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValue;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockArrayVariants;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithNotCastedDateTimeInput;
@@ -602,6 +603,32 @@ abstract class ObjectHydrationTestCase extends TestCase
         $object = $hydrator->hydrateObject(ClassWithDocblockAndArrayFollowingScalar::class, $payload);
 
         self::assertInstanceOf(ClassWithDocblockAndArrayFollowingScalar::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_a_class_with_valid_docblock_array_different_formats(): void {
+        $hydrator = $this->createObjectHydrator();
+        $payload = [
+            'test' => ['Brad', 'Jones'],
+            'test2' => ['Buffy', 'Witt'],
+            'test3' => ['Flying', 'Spaghetti', 'Monster'],
+            'test4' => ['One' => 1, 'Two' => 2],
+            'test5' => [0 => 'Zero', 'One' => 'One'],
+            'test6' => [['defaultsToNull' => 'Array member that is cast to an object.']],
+            'test7' => [[]],
+            'test8' => [[]],
+            'test9' => [[]],
+            'test10' => [[]],
+        ];
+
+        $object = $hydrator->hydrateObject(ClassWithDocblockArrayVariants::class, $payload);
+
+        foreach (['test6', 'test7', 'test8', 'test9', 'test10'] as $property) {
+            self::assertContainsOnlyInstancesOf(ClassWithNullableProperty::class, $object->{$property});
+        }
+        self::assertInstanceOf(ClassWithDocblockArrayVariants::class, $object);
     }
 
     protected function createObjectHydratorFor81(): ObjectMapper

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -607,6 +607,7 @@ abstract class ObjectHydrationTestCase extends TestCase
 
     /**
      * @test
+     * @see https://github.com/EventSaucePHP/ObjectHydrator/issues/56
      */
     public function hydrating_a_class_with_valid_docblock_array_different_formats(): void {
         $hydrator = $this->createObjectHydrator();


### PR DESCRIPTION
Fixes #56 

Also cleaned up some extraneous escaping on regexes to make them more readable. I also suspect that the one for the phpstan syntax might not have been working correctly, anyway, since we didn't have test coverage for that syntax.