### PR TITLE
Allow casters to parse null values and provide default or Injected values

### DIFF
--- a/src/Fixtures/ClassWithDefaultValueProvidingCaster.php
+++ b/src/Fixtures/ClassWithDefaultValueProvidingCaster.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+class ClassWithDefaultValueProvidingCaster
+{
+    public function __construct(
+        #[DefaultValueProvidingCaster]
+        public string $valueProvidedFromCaster,
+    ) {
+    }
+}

--- a/src/Fixtures/DefaultValueProvidingCaster.php
+++ b/src/Fixtures/DefaultValueProvidingCaster.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use Attribute;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class DefaultValueProvidingCaster implements PropertyCaster
+{
+    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    {
+        return 'some_default_value';
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -15,6 +15,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatUsesMutipleCastersWithoutOptions;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithComplexTypeThatIsMapped;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValueProvidingCaster;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockAndArrayFollowingScalar;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValue;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockArrayVariants;
@@ -464,6 +465,17 @@ abstract class ObjectHydrationTestCase extends TestCase
 
         self::assertInstanceOf(ClassWithNullableProperty::class, $object);
         self::assertNull($object->defaultsToNull);
+    }
+
+    /** @test */
+    public function hydrating_a_class_with_a_default_value_providing_caster(): void
+    {
+        $hydrator = $this->createObjectHydrator();
+
+        $object = $hydrator->hydrateObject(ClassWithDefaultValueProvidingCaster::class, []);
+
+        self::assertInstanceOf(ClassWithDefaultValueProvidingCaster::class, $object);
+        self::assertEquals('some_default_value', $object->valueProvidedFromCaster);
     }
 
     /**

--- a/src/ObjectMapperCodeGenerator.php
+++ b/src/ObjectMapperCodeGenerator.php
@@ -245,11 +245,6 @@ CODE;
                 $body .= <<<CODE
 
             \$value = \$payload['$from'] ?? null;
-
-            if (\$value === null) {
-$isNullBody
-            }
-
 CODE;
             } else {
                 $collectKeys = '';
@@ -295,14 +290,19 @@ CODE;
             }
 
             \$value = \${$casterName}->cast(\$value, \$this);
-
-            if (\$value === null) {
-                $isNullBody
-            }
-
 CODE;
                 }
             }
+
+            if(isset($isNullBody)){
+                $body .= <<<CODE
+            if (\$value === null) {
+                $isNullBody
+            }
+CODE;
+            }
+
+
 
             if ($definition->isBackedEnum()) {
                 $body .= <<<CODE

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -98,18 +98,6 @@ class ObjectMapperUsingReflection implements ObjectMapper
                 $property = $definition->accessorName;
                 $value = $this->extractPayloadViaMap($payload, $keys);
 
-                // same code as two sections below
-                if ($value === null) {
-                    if ($definition->hasDefaultValue) {
-                        continue;
-                    } elseif ($definition->nullable) {
-                        $properties[$property] = null;
-                    } else {
-                        $missingFields[] = implode('.', end($keys));
-                    }
-                    continue;
-                }
-
                 foreach ($definition->casters as [$caster, $options]) {
                     $key = $className . '-' . $caster . '-' . json_encode($options);
                     /** @var PropertyCaster $propertyCaster */
@@ -117,7 +105,6 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     $value = $propertyCaster->cast($value, $this);
                 }
 
-                // same code as two sections above
                 if ($value === null) {
                     if ($definition->hasDefaultValue) {
                         continue;

--- a/src/PropertyCasters/CastToDateTimeImmutable.php
+++ b/src/PropertyCasters/CastToDateTimeImmutable.php
@@ -23,6 +23,10 @@ final class CastToDateTimeImmutable implements PropertyCaster, PropertySerialize
 
     public function cast(mixed $value, ObjectMapper $hydrator): mixed
     {
+        if($value === null){
+            return null;
+        }
+
         $timeZone = $this->timeZone ? new DateTimeZone($this->timeZone) : $this->timeZone;
 
         if ($this->format !== null) {


### PR DESCRIPTION
In my project I'm using the ObjectHydrator in order to parse api calls to commands and queries. 

One caster that would really improve DX would be a "AuthenticatedUser" caster, providing the UserId that is authenticated in the session.

In code, usage of it would look like this: 
```php
/** @implements Query<array<Organization>> */
#[ApiQuery]
final readonly class GetUserOrganisations implements Query
{
    public function __construct(
        #[AuthenticatedUser]
        public UserId $userId,
        public int $limit = 10,
    ) {}
}
```

And the "caster" itself would look something like this: 
```php
#[Attribute(Attribute::TARGET_PARAMETER)]
final readonly class AuthenticatedUser implements PropertyCaster
{
    public function cast(mixed $value, ObjectMapper $hydrator): mixed
    {
        $user = \Auth::user();
        if($user === null) {
            throw new \Exception("User not authenticated");
        }

        return UserId::fromString($user->id);
    }
}```


In order for this to work, we need to skip the null check before casters are triggered, and allow casters to process a value of null. This PR enables that. 


Technically we could discuss if providing the Authenticated User ID is a "caster". However I wouldn't know what else to call it, and it seems a bit heavy to introduce a lot of code to support this simple use-case. Open to suggestions though!

Note, this is a breaking change, since current casters might not expect to handle `null` as value. 
See the change I had to make to  src/PropertyCasters/CastToDateTimeImmutable.php as example. 