### PR TITLE
Cast using expected type

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ class CastToMoney implements PropertyCaster
         private string $currency
     ) {}
 
-    public function cast(mixed $value, ObjectMapper $mapper) : mixed
+    public function cast(mixed $value, ObjectMapper $mapper, ?string $expectedTypeName) : mixed
     {
         return new Money($value, Currency::fromString($this->currency));
     }
@@ -416,7 +416,7 @@ class CastUnionToType implements PropertyCaster
         private array $typeToClassMap
     ) {}
 
-    public function cast(mixed $value, ObjectMapper $mapper) : mixed
+    public function cast(mixed $value, ObjectMapper $mapper, ?string $expectedTypeName) : mixed
     {
         assert(is_array($value));
 

--- a/src/Fixtures/CastEmptyStringToNull.php
+++ b/src/Fixtures/CastEmptyStringToNull.php
@@ -9,7 +9,7 @@ use EventSauce\ObjectHydrator\PropertyCaster;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final class CastEmptyStringToNull implements PropertyCaster
 {
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         if ($value === '') {
             return null;

--- a/src/Fixtures/CastToClassWithStaticConstructor.php
+++ b/src/Fixtures/CastToClassWithStaticConstructor.php
@@ -11,7 +11,7 @@ use EventSauce\ObjectHydrator\PropertyCaster;
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final class CastToClassWithStaticConstructor implements PropertyCaster
 {
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         return $hydrator->hydrateObject(ClassWithStaticConstructor::class, ['name' => $value]);
     }

--- a/src/Fixtures/CastToExpectedType/AuthorId.php
+++ b/src/Fixtures/CastToExpectedType/AuthorId.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastToExpectedType;
+
+final class AuthorId
+{
+    public function __construct(
+        private string $id
+    ) {}
+    public static function fromString(string $id): static
+    {
+        return new static($id);
+    }
+
+    public function toString(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Fixtures/CastToExpectedType/BlogId.php
+++ b/src/Fixtures/CastToExpectedType/BlogId.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastToExpectedType;
+
+final class BlogId
+{
+    public function __construct(
+        private string $id
+    ) {}
+    public static function fromString(string $id): static
+    {
+        return new static($id);
+    }
+
+    public function toString(): string
+    {
+        return $this->id;
+    }
+}

--- a/src/Fixtures/CastToExpectedType/ClassWithIds.php
+++ b/src/Fixtures/CastToExpectedType/ClassWithIds.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastToExpectedType;
+
+final class ClassWithIds
+{
+    public function __construct(
+        #[IdCaster]
+        public AuthorId $authorId,
+        #[IdCaster]
+        public BlogId $blogId,
+    )
+    {
+    }
+}

--- a/src/Fixtures/CastToExpectedType/IdCaster.php
+++ b/src/Fixtures/CastToExpectedType/IdCaster.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures\CastToExpectedType;
+
+use Attribute;
+use EventSauce\ObjectHydrator\ObjectMapper;
+use EventSauce\ObjectHydrator\PropertyCaster;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class IdCaster implements PropertyCaster
+{
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
+    {
+        if ($expectedTypeName === null) {
+            throw new \RuntimeException('Expected type name is required');
+        }
+        return $expectedTypeName::fromString($value);
+    }
+}

--- a/src/Fixtures/CastToLowerCase.php
+++ b/src/Fixtures/CastToLowerCase.php
@@ -12,7 +12,7 @@ use function strtolower;
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final class CastToLowerCase implements PropertyCaster
 {
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         return strtolower((string) $value);
     }

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -6,6 +6,9 @@ namespace EventSauce\ObjectHydrator;
 
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFrom;
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFromMultiple;
+use EventSauce\ObjectHydrator\Fixtures\CastToExpectedType\AuthorId;
+use EventSauce\ObjectHydrator\Fixtures\CastToExpectedType\BlogId;
+use EventSauce\ObjectHydrator\Fixtures\CastToExpectedType\ClassWithIds;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToDifferentTypes;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatContainsAnotherClass;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
@@ -621,6 +624,23 @@ abstract class ObjectHydrationTestCase extends TestCase
         $object = $hydrator->hydrateObject(ClassWithDocblockAndArrayFollowingScalar::class, $payload);
 
         self::assertInstanceOf(ClassWithDocblockAndArrayFollowingScalar::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrating_a_class_casting_expected_types(): void {
+        $hydrator = $this->createObjectHydrator();
+        $payload = [
+            'authorId' => 'a',
+            'blogId' => 'b',
+        ];
+
+        $object = $hydrator->hydrateObject(ClassWithIds::class, $payload);
+
+        self::assertInstanceOf(ClassWithIds::class, $object);
+        self::assertInstanceOf(AuthorId::class, $object->authorId);
+        self::assertInstanceOf(BlogId::class, $object->blogId);
     }
 
     /**

--- a/src/ObjectMapperCodeGenerator.php
+++ b/src/ObjectMapperCodeGenerator.php
@@ -294,7 +294,7 @@ CODE;
                 \$$casterName = new \\$caster(...$casterOptions);
             }
 
-            \$value = \${$casterName}->cast(\$value, \$this);
+            \$value = \${$casterName}->cast(\$value, \$this, '$definition->firstTypeName');
 
             if (\$value === null) {
                 $isNullBody

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -110,11 +110,13 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     continue;
                 }
 
+                $typeName = $definition->firstTypeName;
+
                 foreach ($definition->casters as [$caster, $options]) {
                     $key = $className . '-' . $caster . '-' . json_encode($options);
                     /** @var PropertyCaster $propertyCaster */
                     $propertyCaster = $this->casterInstances[$key] ??= new $caster(...$options);
-                    $value = $propertyCaster->cast($value, $this);
+                    $value = $propertyCaster->cast($value, $this, $typeName);
                 }
 
                 // same code as two sections above
@@ -133,7 +135,7 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     $value = $this->hydrateViaTypeMap($definition, $value);
                 }
 
-                $typeName = $definition->firstTypeName;
+
 
                 if ($definition->isBackedEnum()) {
                     $value = $typeName::from($value);

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -8,6 +8,7 @@ use DateTime;
 use DateTimeImmutable;
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFrom;
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFromMultiple;
+use EventSauce\ObjectHydrator\Fixtures\CastToExpectedType\ClassWithIds;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionOne;
 use EventSauce\ObjectHydrator\Fixtures\ClassReferencedByUnionTwo;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatOmitsPublicMethods;

--- a/src/PropertyCaster.php
+++ b/src/PropertyCaster.php
@@ -6,5 +6,5 @@ namespace EventSauce\ObjectHydrator;
 
 interface PropertyCaster
 {
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed;
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed;
 }

--- a/src/PropertyCasters/CastListToType.php
+++ b/src/PropertyCasters/CastListToType.php
@@ -31,7 +31,7 @@ final class CastListToType implements PropertyCaster, PropertySerializer
         $this->isEnum = enum_exists($this->propertyType);
     }
 
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         assert(is_array($value), 'value is expected to be an array');
 

--- a/src/PropertyCasters/CastToArrayWithKey.php
+++ b/src/PropertyCasters/CastToArrayWithKey.php
@@ -17,7 +17,7 @@ final class CastToArrayWithKey implements PropertyCaster, PropertySerializer
     {
     }
 
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         return [$this->key => $value];
     }

--- a/src/PropertyCasters/CastToDateTimeImmutable.php
+++ b/src/PropertyCasters/CastToDateTimeImmutable.php
@@ -21,7 +21,7 @@ final class CastToDateTimeImmutable implements PropertyCaster, PropertySerialize
     {
     }
 
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         $timeZone = $this->timeZone ? new DateTimeZone($this->timeZone) : $this->timeZone;
 

--- a/src/PropertyCasters/CastToType.php
+++ b/src/PropertyCasters/CastToType.php
@@ -19,7 +19,7 @@ final class CastToType implements PropertyCaster, PropertySerializer
     ) {
     }
 
-    public function cast(mixed $value, ObjectMapper $hydrator): mixed
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): mixed
     {
         settype($value, $this->propertyType);
 

--- a/src/PropertyCasters/CastToUuid.php
+++ b/src/PropertyCasters/CastToUuid.php
@@ -20,7 +20,7 @@ final class CastToUuid implements PropertyCaster, PropertySerializer
     {
     }
 
-    public function cast(mixed $value, ObjectMapper $hydrator): UuidInterface
+    public function cast(mixed $value, ObjectMapper $hydrator, ?string $expectedTypeName): UuidInterface
     {
         $value = (string) $value;
 


### PR DESCRIPTION
> This is a breaking change, since the interface of the caster changes. So probably need to be queued for a major release.

In my casters I sometimes need the expected type. Eg: when casting a EventSauce Id It is cumbersome to pass the expected ID class to the caster when it is already typehinted in the constructor 

```php
final readonly class SomeCommand
{
    public function __construct(
        #[IdCaster(AuthorId::class)]
        public AuthorId $authorId,
    ) {}
}

```

The expected type is already known in the hydrator, so with this PR we can change the caster to:

```php
final readonly class SomeCommand
{
    public function __construct(
        #[IdCaster]
        public AuthorId $authorId,
    ) {}
}
```

Or even register it is default caster, so we don't have to annotate our ID's anymore. 

> This is a breaking change, since the interface of the caster changes