### PR TITLE
Support `list<*>`

### DIFF
--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -195,7 +195,7 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
             return substr($type, 0, -2);
         }
 
-        if (preg_match('/array<(?:(int(?:eger)?|string|mixed),\s*)?([A-Za-z0-9\\\]+)>/', $type, $matches)) {
+        if (preg_match('/(?:array|list)<(?:(int(?:eger)?|string|mixed),\s*)?([A-Za-z0-9\\\]+)>/', $type, $matches)) {
             return $matches[2];
         }
 


### PR DESCRIPTION
This adds support for `list<int>`, `list<int,string>`, and so on, in addition to `array<*>`, because it's a widely-used¹ way to distinguish between an associative array, and a list

1) At least psalm and phpstan use it, and PHP language calls these list as well.