### PR TITLE
Improve DefaultCasterRepository and DefaultSerializerRepository constructor

### DIFF
--- a/src/DefaultCasterRepository.php
+++ b/src/DefaultCasterRepository.php
@@ -13,9 +13,11 @@ use Ramsey\Uuid\UuidInterface;
 final class DefaultCasterRepository
 {
     /**
-     * @var array<class-string, array<class-string|<|PropertyCaster>, array<mixed>>>
+     * @param array<class-string, array{0: class-string<PropertyCaster>, 1: array<mixed>}> $casters
      */
-    private array $casters = [];
+    public function __construct(private array $casters = [])
+    {
+    }
 
     /**
      * BC forwarding function.

--- a/src/DefaultSerializerRepository.php
+++ b/src/DefaultSerializerRepository.php
@@ -17,7 +17,7 @@ class DefaultSerializerRepository
     /**
      * @param array<string, array{0: class-string<PropertySerializer>, 1: array<mixed>}> $serializersPerType
      */
-    public function __construct(private array $serializersPerType)
+    public function __construct(private array $serializersPerType = [])
     {
     }
 


### PR DESCRIPTION
This fixes a very minor pet peeve I have with these two classes;
- The caster repository's casters cannot be passed to its constructor
- The serializer repository's serializers parameter is required

This means that if you build them from scratch you cannot use them in the same way, e.g.

```php
$casters = new DefaultCasterRepository();
$serializers = new DefaultSerializerRepository();

...
```