### PR TITLE
Add enum support to `SerializeArrayItems`

### DIFF
--- a/src/FixturesFor81/ClassWithEnumArrayProperty.php
+++ b/src/FixturesFor81/ClassWithEnumArrayProperty.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\FixturesFor81;
+
+final class ClassWithEnumArrayProperty
+{
+    public function __construct(
+        public array $values,
+    ) {
+    }
+}

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -24,9 +24,12 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithUnionProperty;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Dog;
+use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumArrayProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumListProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\ClassWithEnumProperty;
 use EventSauce\ObjectHydrator\FixturesFor81\CustomEnum;
+use EventSauce\ObjectHydrator\FixturesFor81\IntegerEnum;
+use EventSauce\ObjectHydrator\FixturesFor81\OptionUnitEnum;
 use PHPUnit\Framework\TestCase;
 use function array_keys;
 use function PHPUnit\Framework\assertEquals;
@@ -308,5 +311,21 @@ abstract class ObjectSerializationTestCase extends TestCase
 
         $payload = $serializer->serializeObject($object);
         self::assertEquals(['mapped_age' => 34, 'name' => 'Frank'], $payload);
+    }
+
+    /**
+     * @test
+     * @requires PHP >= 8.1
+     */
+    public function serializing_enum_array_items(): void
+    {
+        $serializer = $this->objectMapperFor81();
+        $object = new ClassWithEnumArrayProperty([
+            IntegerEnum::One,
+            OptionUnitEnum::OptionA,
+        ]);
+
+        $payload = $serializer->serializeObject($object);
+        self::assertSame(['values' => [1, 'OptionA']], $payload);
     }
 }

--- a/src/PropertySerializers/SerializeArrayItems.php
+++ b/src/PropertySerializers/SerializeArrayItems.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace EventSauce\ObjectHydrator\PropertySerializers;
 
 use Attribute;
+use BackedEnum;
 use EventSauce\ObjectHydrator\ObjectMapper;
 use EventSauce\ObjectHydrator\PropertySerializer;
+use UnitEnum;
 use function assert;
 use function is_array;
 use function is_object;
@@ -20,7 +22,11 @@ class SerializeArrayItems implements PropertySerializer
 
         foreach ($value as $index => $item) {
             if (is_object($item)) {
-                $value[$index] = $hydrator->serializeObject($item);
+                $value[$index] = match (true) {
+                    $item instanceof BackedEnum => $item->value,
+                    $item instanceof UnitEnum => $item->name,
+                    default => $hydrator->serializeObject($item),
+                };
             }
         }
 


### PR DESCRIPTION
This adds support for backed and unit enums to `#[SerializeArrayItems]`.

Long term it probably makes sense to make the following work:

```php
$objectMapper->serializeObject($enum);
$objectMapper->hydrateObject(MyEnum::class, $payload);
```

That way this logic doesn't have to be implemented in all property casters/serializers individually