### PR TITLE
Add support for custom constructor resolution logic

### DIFF
--- a/src/AttributeConstructorResolver.php
+++ b/src/AttributeConstructorResolver.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EventSauce\ObjectHydrator;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+final class AttributeConstructorResolver implements ConstructorResolver
+{
+    public function resolveConstructor(ReflectionClass $reflectionClass): ?ReflectionMethod
+    {
+        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC);
+
+        foreach ($methods as $method) {
+            $isConstructor = $method->getAttributes(Constructor::class);
+
+            if (count($isConstructor) !== 0) {
+                return $method;
+            }
+        }
+
+        return $reflectionClass->getConstructor();
+    }
+}

--- a/src/ConstructorResolver.php
+++ b/src/ConstructorResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EventSauce\ObjectHydrator;
+
+use ReflectionClass;
+use ReflectionMethod;
+
+interface ConstructorResolver
+{
+    public function resolveConstructor(ReflectionClass $reflectionClass): ?ReflectionMethod;
+}

--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -29,6 +29,7 @@ final class DefinitionProvider
 
     private PropertyTypeResolver $propertyTypeResolver;
     private bool $serializePublicMethods;
+    private ConstructorResolver $constructorResolver;
 
     public function __construct(
         DefaultCasterRepository     $defaultCasterRepository = null,
@@ -36,6 +37,7 @@ final class DefinitionProvider
         DefaultSerializerRepository $defaultSerializerRepository = null,
         PropertyTypeResolver        $propertyTypeResolver = null,
         bool                        $serializePublicMethods = true,
+        ConstructorResolver         $constructorResolver = null,
     )
     {
         $this->defaultCasters = $defaultCasterRepository ?? DefaultCasterRepository::builtIn();
@@ -43,6 +45,7 @@ final class DefinitionProvider
         $this->defaultSerializers = $defaultSerializerRepository ?? DefaultSerializerRepository::builtIn();
         $this->propertyTypeResolver = $propertyTypeResolver ?? new NaivePropertyTypeResolver();
         $this->serializePublicMethods = $serializePublicMethods;
+        $this->constructorResolver = $constructorResolver ?? new AttributeConstructorResolver();
     }
 
     /**
@@ -62,7 +65,7 @@ final class DefinitionProvider
         }
 
         $reflectionClass = new ReflectionClass($className);
-        $constructor = $this->resolveConstructor($reflectionClass);
+        $constructor = $this->constructorResolver->resolveConstructor($reflectionClass);
         $classAttributes = $reflectionClass->getAttributes();
 
         /** @var PropertyHydrationDefinition[] $definitions */
@@ -137,21 +140,6 @@ final class DefinitionProvider
             $mapFrom,
             ...$definitions,
         );
-    }
-
-    private function resolveConstructor(ReflectionClass $reflectionClass): ?ReflectionMethod
-    {
-        $methods = $reflectionClass->getMethods(ReflectionMethod::IS_STATIC | ReflectionMethod::IS_PUBLIC);
-
-        foreach ($methods as $method) {
-            $isConstructor = $method->getAttributes(Constructor::class);
-
-            if (count($isConstructor) !== 0) {
-                return $method;
-            }
-        }
-
-        return $reflectionClass->getConstructor();
     }
 
     private function stringifyConstructor(ReflectionMethod $constructor): string


### PR DESCRIPTION
Right now there is no way to tell the hydrator what the class constructor is, apart from using the `#[Constructor]` attribute. This works fine for first party classes, but less so for third party classes, which (usually) should not be edited directly.

This PR adds a new way to deal with this (without being forced to write casters) by allowing developers to pass an instance of a new `ConstructorResolver` interface to the definition provider. A default implementation of this interface was added so that it works the same way as it does currently.