### PR TITLE
Use more specific return types for property serializers

### DIFF
--- a/src/PropertyCasters/CastToDateTimeImmutable.php
+++ b/src/PropertyCasters/CastToDateTimeImmutable.php
@@ -36,7 +36,7 @@ final class CastToDateTimeImmutable implements PropertyCaster, PropertySerialize
         return new DateTimeImmutable($value, $timeZone);
     }
 
-    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    public function serialize(mixed $value, ObjectMapper $hydrator): string
     {
         assert($value instanceof DateTimeInterface);
 

--- a/src/PropertySerializers/SerializeDateTime.php
+++ b/src/PropertySerializers/SerializeDateTime.php
@@ -17,7 +17,7 @@ class SerializeDateTime implements PropertySerializer
     {
     }
 
-    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    public function serialize(mixed $value, ObjectMapper $hydrator): string
     {
         assert($value instanceof DateTimeInterface);
 

--- a/src/PropertySerializers/SerializeUuidToString.php
+++ b/src/PropertySerializers/SerializeUuidToString.php
@@ -17,7 +17,7 @@ class SerializeUuidToString implements PropertySerializer
     {
     }
 
-    public function serialize(mixed $value, ObjectMapper $hydrator): mixed
+    public function serialize(mixed $value, ObjectMapper $hydrator): string
     {
         assert($value instanceof UuidInterface);
 


### PR DESCRIPTION
Replaced mixed return types in property serializers with more specific alternatives where applicable. This improves type accuracy, supports better static analysis, and clarifies expected serializer outputs.