### PR TITLE
(fix) Add Correct targeting on attributes that work with property promotion

### DIFF
--- a/src/PropertyCasters/CastToArrayWithKey.php
+++ b/src/PropertyCasters/CastToArrayWithKey.php
@@ -10,7 +10,7 @@ use EventSauce\ObjectHydrator\PropertyCaster;
 use EventSauce\ObjectHydrator\PropertySerializer;
 use function is_object;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class CastToArrayWithKey implements PropertyCaster, PropertySerializer
 {
     public function __construct(private string $key)

--- a/src/PropertyCasters/CastToDateTimeImmutable.php
+++ b/src/PropertyCasters/CastToDateTimeImmutable.php
@@ -14,7 +14,7 @@ use EventSauce\ObjectHydrator\PropertySerializer;
 use function assert;
 use function is_int;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class CastToDateTimeImmutable implements PropertyCaster, PropertySerializer
 {
     public function __construct(private ?string $format = null, private ?string $timeZone = null)

--- a/src/PropertyCasters/CastToType.php
+++ b/src/PropertyCasters/CastToType.php
@@ -10,7 +10,7 @@ use EventSauce\ObjectHydrator\PropertyCaster;
 use EventSauce\ObjectHydrator\PropertySerializer;
 use function settype;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class CastToType implements PropertyCaster, PropertySerializer
 {
     public function __construct(

--- a/src/PropertyCasters/CastToUuid.php
+++ b/src/PropertyCasters/CastToUuid.php
@@ -13,7 +13,7 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use function assert;
 
-#[Attribute(Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 final class CastToUuid implements PropertyCaster, PropertySerializer
 {
     public function __construct(private string $type = 'string')


### PR DESCRIPTION
Fixes #81.

I attempted to add some tests that would ensure that attributes used against promoted properties implement both targets but there doesn't actually appear to be a way to do that programatically. The test appears to be "make a new instance and trap the error".