### PR TITLE
Enable users to filter out null values during serialisation

### DIFF
--- a/src/ObjectMapperCodeGeneratorSerializationTest.php
+++ b/src/ObjectMapperCodeGeneratorSerializationTest.php
@@ -37,15 +37,19 @@ class ObjectMapperCodeGeneratorSerializationTest extends ObjectSerializationTest
         self::assertInstanceOf(ClassWithMappedStringProperty::class, $object);
     }
 
-    private function createDumpedObjectHydrator(string $directory, string $className, DefinitionProvider $definitionProvider): ObjectMapper
-    {
+    private function createDumpedObjectHydrator(
+        string $directory,
+        string $className,
+        DefinitionProvider $definitionProvider,
+        bool $omitNullValuesOnSerialization,
+    ): ObjectMapper {
         if (class_exists($className, false)) {
             goto create_object_hydrator;
         }
 
         $classes = ConstructFinder::locatedIn($directory)->findClassNames();
         $interfaces = ConstructFinder::locatedIn($directory)->findInterfaceNames();
-        $dumper = new ObjectMapperCodeGenerator($definitionProvider);
+        $dumper = new ObjectMapperCodeGenerator($definitionProvider, $omitNullValuesOnSerialization);
 
         $dumpedDefinition = $dumper->dump(
             [...$classes, ...$interfaces],
@@ -69,16 +73,26 @@ class ObjectMapperCodeGeneratorSerializationTest extends ObjectSerializationTest
         $definitionProvider ??= $this->defaultDefinitionProvider;
         $className = 'AcmeCorp\\DumpedHydrator' . spl_object_hash($definitionProvider);
 
-        return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', $className, $definitionProvider);
+        return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', $className, $definitionProvider, false);
     }
 
-    public function objectMapper(): ObjectMapper
+    public function objectMapper(bool $omitNullValuesOnSerialization = false): ObjectMapper
     {
-        return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', 'AcmeCorp\\DumpedHydrator', $this->defaultDefinitionProvider);
+        return $this->createDumpedObjectHydrator(
+            __DIR__ . '/Fixtures',
+            'AcmeCorp\\DumpedHydrator' . ($omitNullValuesOnSerialization ? 'SkippingNullOnSerialization' : ''),
+            $this->defaultDefinitionProvider,
+            $omitNullValuesOnSerialization,
+        );
     }
 
     protected function objectMapperFor81(): ObjectMapper
     {
-        return $this->createDumpedObjectHydrator(__DIR__ . '/FixturesFor81', 'AcmeCorp\\DumpedHydratorFor81', $this->defaultDefinitionProvider);
+        return $this->createDumpedObjectHydrator(
+            __DIR__ . '/FixturesFor81',
+            'AcmeCorp\\DumpedHydratorFor81',
+            $this->defaultDefinitionProvider,
+            false,
+        );
     }
 }

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -37,10 +37,14 @@ class ObjectMapperUsingReflection implements ObjectMapper
     /** @var string[] */
     private array $hydrationStack = [];
 
+    private bool $omitNullValuesOnSerialization;
+
     public function __construct(
         ?DefinitionProvider $definitionProvider = null,
+        bool $omitNullValuesOnSerialization = false,
     ) {
         $this->definitionProvider = $definitionProvider ?? new DefinitionProvider();
+        $this->omitNullValuesOnSerialization = $omitNullValuesOnSerialization;
     }
 
     private function extractPayloadViaMap(array $payload, array $inputMap): mixed
@@ -324,6 +328,12 @@ class ObjectMapperUsingReflection implements ObjectMapper
             foreach ($toPath as $to) {
                 $r[$to] ??= [];
                 $r = &$r[$to];
+            }
+
+            $resolvedValue = $mapFromSingleKey ? $value : $value[$payloadKey];
+
+            if ($resolvedValue === null && $this->omitNullValuesOnSerialization) {
+                continue;
             }
 
             $r[$lastKey] = $mapFromSingleKey ? $value : $value[$payloadKey];

--- a/src/ObjectMapperUsingReflectionSerializationTest.php
+++ b/src/ObjectMapperUsingReflectionSerializationTest.php
@@ -6,9 +6,9 @@ namespace EventSauce\ObjectHydrator;
 
 class ObjectMapperUsingReflectionSerializationTest extends ObjectSerializationTestCase
 {
-    public function objectMapper(): ObjectMapper
+    public function objectMapper(bool $omitNullValuesOnSerialization = false): ObjectMapper
     {
-        return new ObjectMapperUsingReflection();
+        return new ObjectMapperUsingReflection(omitNullValuesOnSerialization: $omitNullValuesOnSerialization);
     }
 
     protected function objectMapperFor81(): ObjectMapper

--- a/src/ObjectSerializationTestCase.php
+++ b/src/ObjectSerializationTestCase.php
@@ -20,6 +20,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithCustomDateTimeSerialization;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithListOfObjects;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMultipleProperties;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithNullableProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithUnionProperty;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\Animal;
 use EventSauce\ObjectHydrator\Fixtures\TypeMapping\ClassThatMapsTypes;
@@ -36,7 +37,7 @@ use function PHPUnit\Framework\assertEquals;
 
 abstract class ObjectSerializationTestCase extends TestCase
 {
-    abstract public function objectMapper(): ObjectMapper;
+    abstract public function objectMapper(bool $omitNullValuesOnSerialization = false): ObjectMapper;
 
     abstract protected function objectMapperFor81(): ObjectMapper;
 
@@ -285,6 +286,19 @@ abstract class ObjectSerializationTestCase extends TestCase
             'nullable_mixed_union' => null,
             'nullable_via_union' => ['number' => 1234],
         ], $payload2);
+    }
+
+    /**
+     * @test
+     */
+    public function serialize_omitting_null_values(): void
+    {
+        $serializer = $this->objectMapper(true);
+        $object1 = new ClassWithNullableProperty(null);
+
+        $payload1 = $serializer->serializeObject($object1);
+
+        self::assertEquals([], $payload1);
     }
 
     /**


### PR DESCRIPTION
Schema formats often don't rely on `null` values to define whether or not a field is optional, e.g. in JSON Schema a property with `"type":"string"` disallows `null` values for it.

This provides an efficient way for users to opt-in into treating `null` as optional fields and simply omitting them from serialised payloads.

More info: https://github.com/EventSaucePHP/ObjectHydrator/discussions/84