### PR TITLE
Add test coverage and documentation for supported list<T> syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The library supports the following formats:
 - `@param array<Type> $name`
 - `@param array<string, Type> $name`
 - `@param array<int, Type> $name`
+- `@param list<Type> $name`
 
 ### Custom mapping key
 

--- a/src/Fixtures/ClassThatCastsListsToBasedOnDocComments.php
+++ b/src/Fixtures/ClassThatCastsListsToBasedOnDocComments.php
@@ -9,14 +9,16 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty as CamelClass;
 class ClassThatCastsListsToBasedOnDocComments
 {
     /**
-     * @param CamelClass[]              $list
+     * @param CamelClass[]              $shortList
      * @param array<string, CamelClass> $map
      * @param array<CamelClass>         $array
+     * @param list<CamelClass>          $list
      */
     public function __construct(
-        public array $list,
+        public array $shortList,
         public array $map,
         public array $array,
+        public array $list,
     ) {
     }
 }

--- a/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
@@ -51,7 +51,7 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
         yield 'class with list type resolve from doc comment' => [
             ClassThatCastsListsToBasedOnDocComments::class,
             [
-                'list' => [
+                'short_list' => [
                     ['snake_case' => 'Frank'],
                     ['snake_case' => 'Renske'],
                 ],
@@ -63,9 +63,13 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                     1 => ['snake_case' => 'Frank'],
                     '2' => ['snake_case' => 'Renske'],
                 ],
+                'list' => [
+                    ['snake_case' => 'Frank'],
+                    ['snake_case' => 'Renske'],
+                ],
             ],
             [
-                'list' => [
+                'shortList' => [
                     'type' => 'list',
                     'values' => ClassWithCamelCaseProperty::class,
                 ],
@@ -75,6 +79,10 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                 ],
                 'array' => [
                     'type' => 'array',
+                    'values' => ClassWithCamelCaseProperty::class,
+                ],
+                'list' => [
+                    'type' => 'list',
                     'values' => ClassWithCamelCaseProperty::class,
                 ],
             ],


### PR DESCRIPTION
Add missing documentation and test coverage for the already supported `list<T>` type hint syntax, ensuring it's properly tested and documented alongside other array type hints.