### PR TITLE
Serialize associative arrays (maps) as objects instead of arrays

### DIFF
--- a/src/ConcreteType.php
+++ b/src/ConcreteType.php
@@ -14,6 +14,8 @@ use function is_a;
  */
 final class ConcreteType
 {
+    public bool $associative = false;
+
     public function __construct(public string $name, public bool $isBuiltIn)
     {
     }

--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -172,16 +172,20 @@ final class DefinitionProvider
             /** @var ReflectionNamedType|ReflectionUnionType $returnType */
             $returnType = $method->getReturnType();
             $attributes = $method->getAttributes();
+
             $typeSpecifier = $this->typeSpecifier($attributes);
+            $resolvedPropertyType = $this->propertyTypeResolver->typeFromMethod($method);
+
             $properties[] = new PropertySerializationDefinition(
                 PropertySerializationDefinition::TYPE_METHOD,
                 $methodName,
                 $this->resolveSerializers($returnType, $attributes),
-                PropertyType::fromReflectionType($returnType),
+                $resolvedPropertyType,
                 $returnType->allowsNull(),
                 $this->resolveKeys($key, $attributes),
                 $typeSpecifier?->key,
                 $typeSpecifier?->map ?: [],
+                $this->serializeMapsAsObjects && $resolvedPropertyType->isAssociativeArray(),
             );
         }
 
@@ -204,7 +208,6 @@ final class DefinitionProvider
             }
 
             $typeSpecifier = $this->typeSpecifier($attributes);
-
             $resolvedPropertyType = $this->propertyTypeResolver->typeFromProperty($property, $constructor);
 
             $properties[] = new PropertySerializationDefinition(

--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -26,6 +26,7 @@ final class DefinitionProvider
     private PropertyTypeResolver $propertyTypeResolver;
     private bool $serializePublicMethods;
     private ConstructorResolver $constructorResolver;
+    private bool $serializeMapsAsObjects;
 
     public function __construct(
         ?DefaultCasterRepository     $defaultCasterRepository = null,
@@ -34,6 +35,7 @@ final class DefinitionProvider
         ?PropertyTypeResolver        $propertyTypeResolver = null,
         bool                         $serializePublicMethods = true,
         ?ConstructorResolver         $constructorResolver = null,
+        bool                         $serializeMapsAsObjects = false,
     )
     {
         $this->defaultCasters = $defaultCasterRepository ?? DefaultCasterRepository::builtIn();
@@ -42,6 +44,7 @@ final class DefinitionProvider
         $this->propertyTypeResolver = $propertyTypeResolver ?? new NaivePropertyTypeResolver();
         $this->serializePublicMethods = $serializePublicMethods;
         $this->constructorResolver = $constructorResolver ?? new AttributeConstructorResolver();
+        $this->serializeMapsAsObjects = $serializeMapsAsObjects;
     }
 
     /**
@@ -146,6 +149,7 @@ final class DefinitionProvider
     public function provideSerializationDefinition(string $className): ClassSerializationDefinition
     {
         $reflection = new ReflectionClass($className);
+        $constructor = $this->constructorResolver->resolveConstructor($reflection);
         $objectSettings = $this->resolveObjectSettings($reflection);
         $classAttributes = $reflection->getAttributes();
         $properties = [];
@@ -200,15 +204,19 @@ final class DefinitionProvider
             }
 
             $typeSpecifier = $this->typeSpecifier($attributes);
+
+            $resolvedPropertyType = $this->propertyTypeResolver->typeFromProperty($property, $constructor);
+
             $properties[] = new PropertySerializationDefinition(
                 PropertySerializationDefinition::TYPE_PROPERTY,
                 $property->getName(),
                 $serializers,
-                PropertyType::fromReflectionType($propertyType),
+                $resolvedPropertyType,
                 $propertyType->allowsNull(),
                 $this->resolveKeys($key, $attributes),
                 $typeSpecifier?->key,
                 $typeSpecifier?->map ?: [],
+                $this->serializeMapsAsObjects && $resolvedPropertyType->isAssociativeArray(),
             );
         }
 

--- a/src/Fixtures/ClassThatHasMultipleCastersOnMapProperty.php
+++ b/src/Fixtures/ClassThatHasMultipleCastersOnMapProperty.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\PropertyCasters\CastToArrayWithKey;
+use EventSauce\ObjectHydrator\PropertyCasters\CastToType;
+
+final class ClassThatHasMultipleCastersOnMapProperty
+{
+    /**
+     * @param array<string, array<string, string>> $map
+     */
+    public function __construct(
+        #[CastToType('array')]
+        #[CastToArrayWithKey('second_level')]
+        #[CastToArrayWithKey('first_level')]
+        public array $map,
+    ) {
+    }
+}

--- a/src/Fixtures/ClassThatSpecifiesArraysWithDocComments.php
+++ b/src/Fixtures/ClassThatSpecifiesArraysWithDocComments.php
@@ -22,4 +22,41 @@ final class ClassThatSpecifiesArraysWithDocComments
         public array $listWithTypeHint,
     ) {
     }
+
+    /**
+     * @return array<string, CamelClass>
+     */
+    public function methodMapWithObjects(): array
+    {
+        return $this->mapWithObjects;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function methodMapWithScalars(): array
+    {
+        return $this->mapWithScalars;
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    public function methodMapWithAssociativeArrays(): array
+    {
+        return $this->mapWithAssociativeArrays;
+    }
+
+    public function methodListWithoutTypeHint(): array
+    {
+        return $this->listWithoutTypeHint;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function methodListWithTypeHint(): array
+    {
+        return $this->listWithTypeHint;
+    }
 }

--- a/src/Fixtures/ClassThatSpecifiesArraysWithDocComments.php
+++ b/src/Fixtures/ClassThatSpecifiesArraysWithDocComments.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty as CamelClass;
+
+final class ClassThatSpecifiesArraysWithDocComments
+{
+    /**
+     * @param array<string, CamelClass> $mapWithObjects
+     * @param array<string, int> $mapWithScalars
+     * @param array<string, array<string, string>> $mapWithAssociativeArrays
+     * @param array<int, string> $listWithTypeHint
+     */
+    public function __construct(
+        public array $mapWithObjects,
+        public array $mapWithScalars,
+        public array $mapWithAssociativeArrays,
+        public array $listWithoutTypeHint,
+        public array $listWithTypeHint,
+    ) {
+    }
+}

--- a/src/FixturesFor81/ClassWithEnumArrayProperty.php
+++ b/src/FixturesFor81/ClassWithEnumArrayProperty.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace EventSauce\ObjectHydrator\FixturesFor81;
 
 final class ClassWithEnumArrayProperty

--- a/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
@@ -7,7 +7,9 @@ namespace EventSauce\ObjectHydrator\IntegrationTests;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToBasedOnDocComments;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToDifferentTypes;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListToScalarType;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnMapProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatSpecifiesArraysWithDocComments;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithCamelCaseProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithPropertyCasting;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithStaticConstructor;
@@ -22,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 
 abstract class HydratingSerializedObjectsTestCase extends TestCase
 {
-    abstract public function objectMapper(): ObjectMapper;
+    abstract public function objectMapper(bool $serializeMapsAsObjects = false): ObjectMapper;
 
     /**
      * @test
@@ -135,6 +137,127 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                 ['enum' => ['type' => IntegerEnum::class]],
             ];
         }
+    }
+
+    /**
+     * @test
+     * @dataProvider arrayDataProvider
+     */
+    public function serializes_associative_arrays_as_objects_based_on_configuration(
+        bool $serializeMapsAsObjects,
+        array $input,
+        array $types,
+    ): void {
+        $mapper = $this->objectMapper(serializeMapsAsObjects: $serializeMapsAsObjects);
+
+        $object = $mapper->hydrateObject(ClassThatSpecifiesArraysWithDocComments::class, $input);
+        $payload = $mapper->serializeObject($object);
+
+        self::assertInstanceOf(ClassThatSpecifiesArraysWithDocComments::class, $object);
+        self::assertEquals($input, $payload);
+        self::assertExpectedTypes($types, $object);
+    }
+
+    public function arrayDataProvider(): iterable
+    {
+        yield 'associative arrays as objects' => [
+            true,
+            [
+                'map_with_objects' => (object) [
+                    'frank' => ['snake_case' => 'Frank'],
+                    'renske' => ['snake_case' => 'Renske'],
+                ],
+                'map_with_scalars' => (object) [
+                    'one' => 1,
+                    'two' => 2,
+                ],
+                'map_with_associative_arrays' => (object) [
+                    'one' => ['key' => 'value'],
+                    'two' => ['another_key' => 'another_value'],
+                ],
+                'list_without_type_hint' => ['Frank', 'Renske'],
+                'list_with_type_hint' => ['Frank', 'Renske'],
+            ],
+            [
+                'mapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
+                'mapWithScalars' => ['type' => 'map', 'values' => 'integer'],
+                'mapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
+                'listWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'listWithTypeHint' => ['type' => 'list', 'values' => 'string'],
+            ]
+        ];
+
+        yield 'associative arrays as arrays' => [
+            false,
+            [
+                'map_with_objects' => [
+                    'frank' => ['snake_case' => 'Frank'],
+                    'renske' => ['snake_case' => 'Renske'],
+                ],
+                'map_with_scalars' => [
+                    'one' => 1,
+                    'two' => 2,
+                ],
+                'map_with_associative_arrays' => [
+                    'one' => ['key' => 'value'],
+                    'two' => ['another_key' => 'another_value'],
+                ],
+                'list_without_type_hint' => ['Frank', 'Renske'],
+                'list_with_type_hint' => ['Frank', 'Renske'],
+            ],
+            [
+                'mapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
+                'mapWithScalars' => ['type' => 'map', 'values' => 'integer'],
+                'mapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
+                'listWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'listWithTypeHint' => ['type' => 'list', 'values' => 'string'],
+            ]
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider associativeArraysWithPropertySerializersDataProvider
+     */
+    public function serializes_associative_arrays_with_property_serializers_as_objects(
+        bool $serializeMapsAsObjects,
+        ClassThatHasMultipleCastersOnMapProperty $expectedObject,
+        array $input,
+    ): void {
+        $mapper = $this->objectMapper($serializeMapsAsObjects);
+
+        $object = $mapper->hydrateObject(ClassThatHasMultipleCastersOnMapProperty::class, $input);
+        self::assertEquals($expectedObject, $object);
+
+        $payload = $mapper->serializeObject($object);
+        self::assertEquals($input, $payload);
+    }
+
+    private function associativeArraysWithPropertySerializersDataProvider(): iterable
+    {
+        yield 'associative arrays as objects' => [
+            true,
+            new ClassThatHasMultipleCastersOnMapProperty([
+                'first_level' => [
+                    'second_level' => ['one' => 1, 'two' => 2, 'three' => 3],
+                ],
+            ]),
+            [
+                'map' => (object) ['one' => 1, 'two' => 2, 'three' => 3],
+            ],
+        ];
+
+        yield 'associative arrays as arrays' => [
+            false,
+            new ClassThatHasMultipleCastersOnMapProperty([
+                'first_level' => [
+                    'second_level' => ['one' => 1, 'two' => 2, 'three' => 3],
+                ],
+            ]),
+            [
+                'map' => ['one' => 1, 'two' => 2, 'three' => 3],
+            ],
+        ];
     }
 
     private static function assertExpectedTypes(array $types, object $object): void

--- a/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
@@ -167,16 +167,24 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                     'frank' => ['snake_case' => 'Frank'],
                     'renske' => ['snake_case' => 'Renske'],
                 ],
-                'map_with_scalars' => (object) [
-                    'one' => 1,
-                    'two' => 2,
-                ],
+                'map_with_scalars' => (object) ['one' => 1, 'two' => 2],
                 'map_with_associative_arrays' => (object) [
                     'one' => ['key' => 'value'],
                     'two' => ['another_key' => 'another_value'],
                 ],
                 'list_without_type_hint' => ['Frank', 'Renske'],
                 'list_with_type_hint' => ['Frank', 'Renske'],
+                'method_map_with_objects' => (object) [
+                    'frank' => ['snake_case' => 'Frank'],
+                    'renske' => ['snake_case' => 'Renske'],
+                ],
+                'method_map_with_scalars' => (object) ['one' => 1, 'two' => 2 ],
+                'method_map_with_associative_arrays' => (object) [
+                    'one' => ['key' => 'value'],
+                    'two' => ['another_key' => 'another_value'],
+                ],
+                'method_list_without_type_hint' => ['Frank', 'Renske'],
+                'method_list_with_type_hint' => ['Frank', 'Renske'],
             ],
             [
                 'mapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
@@ -184,6 +192,11 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                 'mapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
                 'listWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
                 'listWithTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'methodMapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
+                'methodMapWithScalars' => ['type' => 'map', 'values' => 'integer'],
+                'methodMapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
+                'methodListWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'methodListWithTypeHint' => ['type' => 'list', 'values' => 'string'],
             ]
         ];
 
@@ -194,16 +207,24 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                     'frank' => ['snake_case' => 'Frank'],
                     'renske' => ['snake_case' => 'Renske'],
                 ],
-                'map_with_scalars' => [
-                    'one' => 1,
-                    'two' => 2,
-                ],
+                'map_with_scalars' => ['one' => 1, 'two' => 2],
                 'map_with_associative_arrays' => [
                     'one' => ['key' => 'value'],
                     'two' => ['another_key' => 'another_value'],
                 ],
                 'list_without_type_hint' => ['Frank', 'Renske'],
                 'list_with_type_hint' => ['Frank', 'Renske'],
+                'method_map_with_objects' => [
+                    'frank' => ['snake_case' => 'Frank'],
+                    'renske' => ['snake_case' => 'Renske'],
+                ],
+                'method_map_with_scalars' => ['one' => 1, 'two' => 2 ],
+                'method_map_with_associative_arrays' => [
+                    'one' => ['key' => 'value'],
+                    'two' => ['another_key' => 'another_value'],
+                ],
+                'method_list_without_type_hint' => ['Frank', 'Renske'],
+                'method_list_with_type_hint' => ['Frank', 'Renske'],
             ],
             [
                 'mapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
@@ -211,6 +232,11 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
                 'mapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
                 'listWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
                 'listWithTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'methodMapWithObjects' => ['type' => 'map', 'values' => ClassWithCamelCaseProperty::class],
+                'methodMapWithScalars' => ['type' => 'map', 'values' => 'integer'],
+                'methodMapWithAssociativeArrays' => ['type' => 'map', 'values' => 'array'],
+                'methodListWithoutTypeHint' => ['type' => 'list', 'values' => 'string'],
+                'methodListWithTypeHint' => ['type' => 'list', 'values' => 'string'],
             ]
         ];
     }
@@ -263,7 +289,7 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
     private static function assertExpectedTypes(array $types, object $object): void
     {
         foreach ($types as $property => $type) {
-            $value = $object->$property;
+            $value = property_exists($object, $property) ? $object->{$property} : $object->$property();
 
             self::assertExpectedType($type['type'], $value);
 

--- a/src/IntegrationTests/HydratingSerializedObjectsUsingCodeGenerationTest.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsUsingCodeGenerationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace EventSauce\ObjectHydrator\IntegrationTests;
 
 use const PHP_VERSION;
+use EventSauce\ObjectHydrator\DefinitionProvider;
 use EventSauce\ObjectHydrator\ObjectMapper;
 use EventSauce\ObjectHydrator\ObjectMapperCodeGenerator;
 use League\ConstructFinder\ConstructFinder;
@@ -16,21 +17,26 @@ use function version_compare;
 
 class HydratingSerializedObjectsUsingCodeGenerationTest extends HydratingSerializedObjectsTestCase
 {
-    public function objectMapper(): ObjectMapper
+    public function objectMapper(bool $serializeMapsAsObjects = false): ObjectMapper
     {
-        $className = 'AcmeCorp\\GeneratedHydrator';
+        $shortClassName = $serializeMapsAsObjects ? 'GeneratedObjectModeHydrator' : 'GeneratedArrayModeHydrator';
+        $className = 'AcmeCorp\\' . $shortClassName;
 
         if (class_exists($className)) {
             goto make_it;
         }
 
         $classes = $this->findClasses();
-        $dumper = new ObjectMapperCodeGenerator();
+        $dumper = new ObjectMapperCodeGenerator(
+            $serializeMapsAsObjects ? new DefinitionProvider(serializeMapsAsObjects: true) : null,
+        );
         $code = $dumper->dump($classes, $className);
 
-        file_put_contents(__DIR__ . '/testHydrator.php', $code);
-        include __DIR__ . '/testHydrator.php';
-        unlink(__DIR__ . '/testHydrator.php');
+        $path = __DIR__ . '/' . $shortClassName . '.php';
+
+        file_put_contents($path, $code);
+        include_once $path;
+        unlink($path);
 
         make_it:
 

--- a/src/IntegrationTests/HydratingSerializedObjectsUsingReflectionTest.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsUsingReflectionTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator\IntegrationTests;
 
+use EventSauce\ObjectHydrator\DefinitionProvider;
 use EventSauce\ObjectHydrator\ObjectMapper;
 use EventSauce\ObjectHydrator\ObjectMapperUsingReflection;
 
 class HydratingSerializedObjectsUsingReflectionTest extends HydratingSerializedObjectsTestCase
 {
-    public function objectMapper(): ObjectMapper
+    public function objectMapper(bool $serializeMapsAsObjects = false): ObjectMapper
     {
-        return new ObjectMapperUsingReflection();
+        return new ObjectMapperUsingReflection(
+            $serializeMapsAsObjects ? new DefinitionProvider(serializeMapsAsObjects: true) : null
+        );
     }
 }

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -16,6 +16,7 @@ use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
+use ReflectionProperty;
 use RuntimeException;
 use function array_key_exists;
 use function array_shift;
@@ -54,6 +55,30 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         return PropertyType::fromReflectionType($type);
+    }
+
+    public function typeFromProperty(ReflectionProperty $property, ?ReflectionMethod $constructor): PropertyType
+    {
+        $propertyType = $property->getType();
+
+        $resolvedType = PropertyType::fromReflectionType($propertyType);
+        $concreteType = $resolvedType->firstType();
+
+        if (!$propertyType instanceof ReflectionNamedType || !$concreteType) {
+            return $resolvedType;
+        }
+
+        if (!$property->isPromoted()) {
+            $associative = $this->isAssociativeBasedOnPropertyDocComment($property);
+        } elseif ($constructor) {
+            $associative = $this->isAssociativeBasedOnConstructorDocComment($property, $constructor);
+        } else {
+            $associative = false;
+        }
+
+        $concreteType->associative = $associative;
+
+        return $resolvedType;
     }
 
     private function resolveUseStatementMap(ReflectionClass $declaringClass): array
@@ -204,5 +229,28 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         throw new LogicException('Unable to resolve item type for type: ' . $type);
+    }
+
+    private function isAssociativeBasedOnConstructorDocComment(ReflectionProperty $parameter, ReflectionMethod $constructor): bool
+    {
+        $docBlock = $constructor->getDocComment();
+        if (!$docBlock) {
+            return false;
+        }
+
+        return (bool) preg_match(
+            '/\*\s+@param\s+[^$]*array<\s*string\s*,\s*[^>]+\s*>[^$]*\$' . preg_quote($parameter->name, '/') . '\b/m',
+            $docBlock
+        );
+    }
+
+    private function isAssociativeBasedOnPropertyDocComment(ReflectionProperty $property): bool
+    {
+        $docBlock = $property->getDocComment();
+        if (!$docBlock) {
+            return false;
+        }
+
+        return (bool) preg_match('/\*\s+@var\s+[^*]*?\barray\s*<\s*string\s*,\s*[^>]+\s*>/m', $docBlock);
     }
 }

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -81,6 +81,22 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         return $resolvedType;
     }
 
+    public function typeFromMethod(ReflectionMethod $method): PropertyType
+    {
+        $returnType = $method->getReturnType();
+
+        $resolvedType = PropertyType::fromReflectionType($returnType);
+        $concreteType = $resolvedType->firstType();
+
+        if (!$returnType instanceof ReflectionNamedType || !$concreteType) {
+            return $resolvedType;
+        }
+
+        $concreteType->associative = $this->isAssociativeBasedOnReturnDocComment($method);
+
+        return $resolvedType;
+    }
+
     private function resolveUseStatementMap(ReflectionClass $declaringClass): array
     {
         static $cache = [];
@@ -252,5 +268,15 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
         }
 
         return (bool) preg_match('/\*\s+@var\s+[^*]*?\barray\s*<\s*string\s*,\s*[^>]+\s*>/m', $docBlock);
+    }
+
+    private function isAssociativeBasedOnReturnDocComment(ReflectionMethod $method): bool
+    {
+        $docBlock = $method->getDocComment();
+        if (!$docBlock) {
+            return false;
+        }
+
+        return (bool) preg_match('/\*\s+@return\s+[^*]*?\barray\s*<\s*string\s*,\s*[^>]+\s*>/m', $docBlock);
     }
 }

--- a/src/ObjectMapperCodeGenerator.php
+++ b/src/ObjectMapperCodeGenerator.php
@@ -255,6 +255,14 @@ $isNullBody
             }
 
 CODE;
+                if ($definition->propertyType->isCollection() || $definition->firstTypeName === 'array') {
+                    $body .= <<<CODE
+            if (is_object(\$value)) {
+                \$value = (array) \$value;
+            }
+
+CODE;
+                }
             } else {
                 $collectKeys = '';
 
@@ -769,10 +777,11 @@ CODE;
 
         if (count($keys) === 1) {
             $key = '[\'' . implode('\'][\'', array_pop($keys)) . '\']';
+            $cast = $definition->enforceObject ? '(object) ' : '';
 
             return $this->omitNullValuesOnSerialization
-                ? "        if ($tempVariable !== null) \$result$key = $tempVariable;\n"
-                : "        \$result$key = $tempVariable;\n";
+                ? "        if ($tempVariable !== null) \$result$key = {$cast}$tempVariable;\n"
+                : "        \$result$key = {$cast}$tempVariable;\n";
         }
 
         $code = '';

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -137,6 +137,10 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     $value = $this->hydrateViaTypeMap($definition, $value);
                 }
 
+                if (is_object($value) && ($definition->propertyType->isCollection() || $definition->firstTypeName === 'array')) {
+                    $value = (array) $value;
+                }
+
                 $typeName = $definition->firstTypeName;
 
                 if ($definition->isBackedEnum()) {
@@ -298,6 +302,8 @@ class ObjectMapperUsingReflection implements ObjectMapper
                     $value = $value->name;
                 } elseif (is_object($value)) {
                     $value = $defaults + $this->serializeObject($value);
+                } elseif ($property->enforceObject) {
+                    $value = (object) $value;
                 }
 
                 $this->assignToResult($keys, $result, $value);

--- a/src/PropertySerializationDefinition.php
+++ b/src/PropertySerializationDefinition.php
@@ -20,6 +20,7 @@ class PropertySerializationDefinition
         public array $keys = [],
         public ?string $typeSpecifier = null,
         public array $typeMap = [],
+        public bool $enforceObject = false,
     ) {
         $this->serializers = array_filter($this->serializers);
     }

--- a/src/PropertyType.php
+++ b/src/PropertyType.php
@@ -8,6 +8,7 @@ use BackedEnum;
 use ReflectionClass;
 use ReflectionIntersectionType;
 use ReflectionNamedType;
+use ReflectionProperty;
 use ReflectionUnionType;
 use function count;
 use function enum_exists;
@@ -78,6 +79,13 @@ final class PropertyType
             && ($this->concreteTypes[0]->isBuiltIn === false);
     }
 
+    public function isAssociativeArray(): bool
+    {
+        return count($this->concreteTypes) === 1
+            && $this->concreteTypes[0]->name === 'array'
+            && $this->concreteTypes[0]->associative;
+    }
+
     public static function fromReflectionType(
         ReflectionUnionType|ReflectionIntersectionType|ReflectionNamedType|null $type
     ): PropertyType {
@@ -130,6 +138,11 @@ final class PropertyType
     public static function mixed(): static
     {
         return new static(true, new ConcreteType('mixed', true));
+    }
+
+    public function firstType(): ?ConcreteType
+    {
+        return $this->concreteTypes[0] ?? null;
     }
 
     public function firstTypeName(): ?string

--- a/src/PropertyTypeResolver.php
+++ b/src/PropertyTypeResolver.php
@@ -6,11 +6,17 @@ namespace EventSauce\ObjectHydrator;
 
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionProperty;
 
 interface PropertyTypeResolver
 {
     public function typeFromConstructorParameter(
         ReflectionParameter $parameter,
         ReflectionMethod $constructor
+    ): PropertyType;
+
+    public function typeFromProperty(
+        ReflectionProperty $property,
+        ?ReflectionMethod $constructor
     ): PropertyType;
 }

--- a/src/PropertyTypeResolver.php
+++ b/src/PropertyTypeResolver.php
@@ -19,4 +19,6 @@ interface PropertyTypeResolver
         ReflectionProperty $property,
         ?ReflectionMethod $constructor
     ): PropertyType;
+
+    public function typeFromMethod(ReflectionMethod $method): PropertyType;
 }


### PR DESCRIPTION
This implementation introduces the ability to serialize associative arrays as objects based on the added configuration. It determines whether an array is associative by analyzing doc-comment annotations.

Doc-comments are used since they provide the most consistent type information about array types. Empty arrays cannot be analyzed at runtime to determine whether they represent lists or maps, since they are identical in structure regardless of their intended type.

For promoted properties, type information is extracted from the `@param` type hint in the constructor doc-comment, for class properties from the `@var` type hint in the property doc-comment, and for methods from the `@return` type hint in the method doc-comment.

### Pre-assignment array transformation
Arrays are cast immediately before property assignment. This cannot be done in the `SerializeArrayItems` property serializer because it lacks access to the extracted `PropertyType` information.

Since identifying associative arrays by analyzing doc-comment type hints requires reflection, which compromises performance, handling this within the `SerializeArrayItems` property serializer would be suboptimal given that property serializers are called directly by the optimized object mapper.

### Recursive processing

The casting of associative arrays does not apply recursively, meaning the format of nested associative arrays remains unchanged. This behavior is reasonable from a serialization standpoint, as associative arrays should be handled as unstructured objects where no guarantees can be provided about their nested elements.

From a hydration perspective, this behavior is compatible with existing functionality. The format of nested associative arrays within parent associative arrays also remains unchanged.

### Limitations

Values are cast to objects regardless of applied property serializers. This approach is reasonable given that associative arrays are unlikely to be represented as types other than (associative) arrays or objects, and property serializers are unlikely to deviate from this representation. Furthermore, when `serializeMapsAsObjects` is explicitly enabled, the consistent object casting aligns with the intended configuration.

### Backward compatibility
This implementation introduces a breaking change by adding the `typeFromProperty()` and `typeFromMethod()` methods to the `PropertyTypeResolver` interface. Since this interface is not marked as `@internal`, adding new methods constitutes a BC break for any existing implementations of this interface.

Associative arrays are not cast to objects by default, so no behavioral breaking changes are introduced and existing serialization behavior is preserved.

Documentation: [#serializing-maps-as-objects](https://github.com/jonmldr/ObjectHydrator/blob/serialize-associative-arrays-as-objects/README.md#serializing-maps-as-objects)