### PR TITLE
Allow outside usage of PropertyType

### DIFF
--- a/src/PropertyType.php
+++ b/src/PropertyType.php
@@ -14,9 +14,6 @@ use function enum_exists;
 use function function_exists;
 use function is_a;
 
-/**
- * @internal
- */
 final class PropertyType
 {
     /** @var ConcreteType[] */


### PR DESCRIPTION
Currently `PropertyType` is marked as `@internal`, but it is used by the `PropertyTypeResolver` interface. Implementing this interface causes errors about using `PropertyType` in newer versions of PHPStan.