### PR TITLE
[PHP8.5 compat] fix: array null key access is deprecated

### DIFF
--- a/src/Fixtures/ClassThatCreatesClassesFromAPath.php
+++ b/src/Fixtures/ClassThatCreatesClassesFromAPath.php
@@ -1,0 +1,22 @@
+<?php
+
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use EventSauce\ObjectHydrator\MapFrom;
+use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
+
+final class ClassThatCreatesClassesFromAPath
+{
+    /**
+     * @param array<int, ClassThatCreatesClassesFromAPathSubclass> $subClasses
+     */
+    public function __construct(
+        #[MapFrom('root.list.classes', '.')]
+        #[CastListToType(ClassThatCreatesClassesFromAPathSubclass::class)]
+        public array $subClasses,
+    ) {
+    }
+}

--- a/src/Fixtures/ClassThatCreatesClassesFromAPathSubclass.php
+++ b/src/Fixtures/ClassThatCreatesClassesFromAPathSubclass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+class ClassThatCreatesClassesFromAPathSubclass
+{
+    public function __construct(
+        public string $subClassName,
+    ) {
+    }
+}

--- a/src/ObjectHydrationTestCase.php
+++ b/src/ObjectHydrationTestCase.php
@@ -8,6 +8,7 @@ use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFr
 use EventSauce\ObjectHydrator\Fixtures\CastersOnClasses\ClassWithClassLevelMapFromMultiple;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToDifferentTypes;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatContainsAnotherClass;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatCreatesClassesFromAPath;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatHasMultipleCastersOnSingleProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatRenamesInputForClassWithMultipleProperties;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatTriggersUseStatementLookup;
@@ -20,6 +21,7 @@ use EventSauce\ObjectHydrator\Fixtures\ClassWithDefaultValue;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithDocblockArrayVariants;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithFormattedDateTimeZoneInput;
+use EventSauce\ObjectHydrator\Fixtures\ClassWithListOfObjects;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithNotCastedDateTimeInput;
 use EventSauce\ObjectHydrator\Fixtures\ClassWithNullableInput;
@@ -635,6 +637,49 @@ abstract class ObjectHydrationTestCase extends TestCase
         $object = $hydrator->hydrateObject(ClassWithDocblockAndArrayFollowingScalar::class, $payload);
 
         self::assertInstanceOf(ClassWithDocblockAndArrayFollowingScalar::class, $object);
+    }
+
+    /**
+     * @test
+     */
+    public function hydrate_a_class_with_a_path_and_subclasses_using_a_docblock_as_typehint(): void {
+        $payload = [
+            'root' => [
+                'list' => [
+                    'classes' => [
+                        ['subClassName' => 'TheSubMarine'],
+                        ['subClassName' => 'TheMainMarine'],
+                    ]
+                ]
+            ]
+        ];
+
+        $object = $this
+            ->createObjectHydrator()
+            ->hydrateObject(ClassThatCreatesClassesFromAPath::class, $payload);
+
+        self::assertInstanceOf(ClassThatCreatesClassesFromAPath::class, $object);
+        self::assertSame('{"subClasses":[{"subClassName":"TheSubMarine"},{"subClassName":"TheMainMarine"}]}', json_encode($object));
+    }
+
+    /**
+     * @test
+     */
+    public function hydrate_a_class_with_a_path_and_subclasses_in_an_empty_array_set_using_a_docblock_as_typehint(): void {
+        $payload = [
+            'root' => [
+                'list' => [
+                    'classes' => []
+                ]
+            ]
+        ];
+
+        $object = $this
+            ->createObjectHydrator()
+            ->hydrateObject(ClassThatCreatesClassesFromAPath::class, $payload);
+
+        self::assertInstanceOf(ClassThatCreatesClassesFromAPath::class, $object);
+        self::assertSame('{"subClasses":[]}', json_encode($object));
     }
 
     /**

--- a/src/ObjectMapperCodeGenerator.php
+++ b/src/ObjectMapperCodeGenerator.php
@@ -322,7 +322,7 @@ CODE;
                 if ($definition->propertyType->isCollection()) {
                     $body .= <<<CODE
 
-            if (is_array(\$value[array_key_first(\$value)] ?? false)) {
+            if (count(\$value) > 0 && is_array(\$value[array_key_first(\$value)] ?? false)) {
                 try {
                     \$this->hydrationStack[] = '$definition->accessorName';
                     \$value = \$this->hydrateObjects('{$definition->firstTypeName}', \$value)->toArray();

--- a/src/ObjectMapperUsingReflection.php
+++ b/src/ObjectMapperUsingReflection.php
@@ -150,7 +150,10 @@ class ObjectMapperUsingReflection implements ObjectMapper
                         $this->hydrationStack[] = $property;
 
                         if ($propertyType->isCollection()) {
-                            if (is_array($value[array_key_first($value)] ?? false)) {
+                            if (
+                                count($value) > 0 &&
+                                is_array($value[array_key_first($value)] ?? false)
+                            ) {
                                 $value = $this->hydrateObjects($propertyType->firstTypeName(), $value)->toArray();
                             }
                         } else {


### PR DESCRIPTION
## Description

Hi Frank and Team,

After upgrading our services to run on PHP 8.5 we started getting deprecation warnings originating from `ObjectHydrator`. 

The problem seems to be that this line `is_array($value[array_key_first($value)] ?? false))` can receive an empty array as first parameter, `array_key_first` returns `null` in that case, and this has been deprecated in PHP 8.5

The way we fixed it in this PR is by checking if the array is empty before attempting any key access, that fixed it in our case.

Currently the test suite does not fail on PHP 8.5, so I have added a test (happy and sad path) to verify this behavior, before fixing it.

I am not sure if the null-coalesce is still required, I think it was originally their to handle the `null` return from the `array_key_first`, I left it for now, but let me know if you feel like it should be removed

Gr Sven