### PR TITLE
Align serialize with hydrator picking up nested DTOs when

### DIFF
--- a/src/ClassExpander.php
+++ b/src/ClassExpander.php
@@ -71,10 +71,14 @@ final class ClassExpander
 
             /** @var PropertySerializationDefinition $property */
             foreach ($classDefinition->properties as $property) {
-                $type = $property->type;
-
-                if ( ! in_array($type, $classes) && self::isClass($type)) {
-                    $classes[] = $type;
+                $types = [$property->type];
+                foreach ($property->propertyType->concreteTypes() as $concreteType) {
+                    $types[] = $concreteType->name;
+                }
+                foreach ($types as $type) {
+                    if (!in_array($type, $classes) && self::isClass($type)) {
+                        $classes[] = $type;
+                    }
                 }
             }
         }

--- a/src/NaivePropertyTypeResolver.php
+++ b/src/NaivePropertyTypeResolver.php
@@ -13,6 +13,7 @@ use const T_USE;
 use const T_WHITESPACE;
 use LogicException;
 use ReflectionClass;
+use ReflectionProperty;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
@@ -37,7 +38,7 @@ use function trim;
 class NaivePropertyTypeResolver implements PropertyTypeResolver
 {
     public function typeFromConstructorParameter(
-        ReflectionParameter $parameter,
+        ReflectionParameter|ReflectionProperty $parameter,
         ReflectionMethod $constructor
     ): PropertyType {
         $type = $parameter->getType();
@@ -124,7 +125,7 @@ class NaivePropertyTypeResolver implements PropertyTypeResolver
     }
 
     private function resolveFromConstructorDocComment(
-        ReflectionParameter $parameter,
+        ReflectionParameter|ReflectionProperty $parameter,
         ReflectionMethod $constructor,
         array $useMap,
     ): false|PropertyType {

--- a/src/ObjectMapperCodeGeneratorSerializationWithOutFeedingAllClassesTest.php
+++ b/src/ObjectMapperCodeGeneratorSerializationWithOutFeedingAllClassesTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator;
+
+use EventSauce\ObjectHydrator\Fixtures\ClassWithMappedStringProperty;
+use function class_exists;
+use function spl_object_hash;
+use function strpos;
+use function unlink;
+
+class ObjectMapperCodeGeneratorSerializationWithOutFeedingAllClassesTest extends ObjectSerializationTestCase
+{
+    private DefinitionProvider $defaultDefinitionProvider;
+
+    /**
+     * @before
+     */
+    public function setupDefaultDefinitionProvider(): void
+    {
+        $this->defaultDefinitionProvider ??= new DefinitionProvider(
+            keyFormatter: new KeyFormatterForSnakeCasing(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function dumping_an_object_hydrator(): void
+    {
+        $objectHydrator = $this->createObjectHydrator();
+
+        $object = $objectHydrator->hydrateObject(ClassWithMappedStringProperty::class, ['my_name' => 'Frank de Jonge']);
+
+        self::assertInstanceOf(ClassWithMappedStringProperty::class, $object);
+    }
+
+    private function createDumpedObjectHydrator(
+        string $directory,
+        string $className,
+        DefinitionProvider $definitionProvider,
+        bool $omitNullValuesOnSerialization,
+    ): ObjectMapper
+    {
+        return new class ($directory, $className, $definitionProvider, $omitNullValuesOnSerialization) implements ObjectMapper {
+            public function __construct(
+                private string $directory,
+                private string $className,
+                private DefinitionProvider $definitionProvider,
+                private bool $omitNullValuesOnSerialization,
+            ) {}
+
+            public function hydrateObject(string $className, array $payload): object
+            {
+                return $this->generateObjectMapper($className)->hydrateObject($className, $payload);
+            }
+
+            public function hydrateObjects(string $className, iterable $payloads): IterableList
+            {
+                return $this->generateObjectMapper($className)->hydrateObjects($className, $payloads);
+            }
+
+            public function serializeObject(object $object): mixed
+            {
+                return $this->generateObjectMapper($object::class)->serializeObject($object);
+            }
+
+            public function serializeObjectOfType(object $object, string $className): mixed
+            {
+                return $this->generateObjectMapper($className)->serializeObjectOfType($object, $className);
+            }
+
+            public function serializeObjects(iterable $payloads): IterableList
+            {
+                return new IterableList($this->doSerializeObjects($payloads));
+            }
+
+            private function doSerializeObjects(iterable $objects): \Generator
+            {
+                foreach ($objects as $index => $object) {
+                    yield $index => $this->serializeObject($object);
+                }
+            }
+
+            private function generateObjectMapper(string $className): ObjectMapper
+            {
+                return $this->createDumpedObjectHydrator(
+                    $this->directory,
+                    $this->className . 'For' . str_replace('\\', '', $className),
+                    $this->definitionProvider,
+                    $this->omitNullValuesOnSerialization,
+                    $className,
+                );
+            }
+
+            private function createDumpedObjectHydrator(
+                string $directory,
+                string $className,
+                DefinitionProvider $definitionProvider,
+                bool $omitNullValuesOnSerialization,
+                string ...$classes,
+            ): ObjectMapper {
+                if (class_exists($className, false)) {
+                    goto create_object_hydrator;
+                }
+
+                $dumper = new ObjectMapperCodeGenerator($definitionProvider, $omitNullValuesOnSerialization);
+
+                $dumpedDefinition = $dumper->dump(
+                    $classes,
+                    $className,
+                );
+                $filename = __DIR__ . '/smart-test' . (strpos($directory, '81') === false ? '80' : '81') . '.php';
+
+                file_put_contents($filename, $dumpedDefinition);
+                include $filename;
+                unlink($filename);
+
+                create_object_hydrator:
+                /** @var ObjectMapper $objectHydrator */
+                $objectHydrator = new $className();
+
+                return $objectHydrator;
+            }
+        };
+    }
+
+    protected function createObjectHydrator(?DefinitionProvider $definitionProvider = null): ObjectMapper
+    {
+        $definitionProvider ??= $this->defaultDefinitionProvider;
+        $className = 'AcmeCorp\\DumpedHydrator' . spl_object_hash($definitionProvider);
+
+        return $this->createDumpedObjectHydrator(__DIR__ . '/Fixtures', $className, $definitionProvider, false);
+    }
+
+    public function objectMapper(bool $omitNullValuesOnSerialization = false): ObjectMapper
+    {
+        return $this->createDumpedObjectHydrator(
+            __DIR__ . '/Fixtures',
+            'AcmeCorp\\SmartHydrator' . ($omitNullValuesOnSerialization ? 'SkippingNullOnSerialization' : ''),
+            $this->defaultDefinitionProvider,
+            $omitNullValuesOnSerialization,
+        );
+    }
+
+    protected function objectMapperFor81(): ObjectMapper
+    {
+        return $this->createDumpedObjectHydrator(
+            __DIR__ . '/FixturesFor81',
+            'AcmeCorp\\SmartHydratorFor81',
+            $this->defaultDefinitionProvider,
+            false,
+        );
+    }
+
+    /**
+     * @test
+     */
+    final public function serializing_a_class_with_polymorphism(): void
+    {
+        $this->markTestSkipped('This specific test isn\'t supported in this specific scenario');
+    }
+
+    /**
+     * @test
+     */
+    final public function serializing_an_interface_with_polymorphism(): void
+    {
+        $this->markTestSkipped('This specific test isn\'t supported in this specific scenario');
+    }
+
+    /**
+     * @test
+     */
+    final public function serializing_a_list_of_custom_objects(): void
+    {
+        $this->markTestSkipped('This specific test isn\'t supported in this specific scenario');
+    }
+}

--- a/src/PropertyTypeResolver.php
+++ b/src/PropertyTypeResolver.php
@@ -6,11 +6,12 @@ namespace EventSauce\ObjectHydrator;
 
 use ReflectionMethod;
 use ReflectionParameter;
+use ReflectionProperty;
 
 interface PropertyTypeResolver
 {
     public function typeFromConstructorParameter(
-        ReflectionParameter $parameter,
+        ReflectionParameter|ReflectionProperty $parameter,
         ReflectionMethod $constructor
     ): PropertyType;
 }


### PR DESCRIPTION
For a project I have a DTO that I want to pass around:

```php
<?php

declare(strict_types=1);

namespace WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full;

use WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile;

final readonly class Worldmap
{
    /** @param array<Tile> $tiles */
    public function __construct(
        public string $type,
        public string $version,
        public string $worldmap,
        public array $tiles,
    ) {
    }
}
```

If has a property that is a list of the following DTO:

```php
<?php

declare(strict_types=1);

namespace WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap;

use EventSauce\ObjectHydrator\MapFrom;
use WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet;

final readonly class Tile
{
    public function __construct(
        #[MapFrom('fileName')]
        public string $fileName,
        #[MapFrom('offSet')]
        public OffSet $offSet,
    ) {
    }
}

```

And that DTO has one final sub DTO as a property:

```php
<?php

declare(strict_types=1);

namespace WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile;

final readonly class OffSet implements Work
{
    public function __construct(
        public int $x,
        public int $y,
    ) {
    }
}
```

Then I generate the Hydrator object with the follwing code:
```php
$hydratorGenerator = new ObjectMapperCodeGenerator();
$code              = $hydratorGenerator->dump([\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap::class], Hydrator::class);
file_put_contents($rootPath . '/src/Generated/Hydrator.php', $code);
```

That generates the following code, the `hydrateObject` method has both the `Tile` and `OffSet` but the `serializeObjectOfType` method is lacking them:

```php
<?php

declare(strict_types=1);

use EventSauce\ObjectHydrator\IterableList;
use EventSauce\ObjectHydrator\ObjectMapper;
use EventSauce\ObjectHydrator\UnableToHydrateObject;
use EventSauce\ObjectHydrator\UnableToSerializeObject;
use Generator;

class Hydrator implements ObjectMapper
{
    private array $hydrationStack = [];
    public function __construct() {}

    /**
     * @template T of object
     * @param class-string<T> $className
     * @return T
     */
    public function hydrateObject(string $className, array $payload): object
    {
        return match($className) {
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap($payload),
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile($payload),
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($payload),
            default => throw UnableToHydrateObject::noHydrationDefined($className, $this->hydrationStack),
        };
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['type'] ?? null;

            if ($value === null) {
                $missingFields[] = 'type';
                goto after_type;
            }

            $properties['type'] = $value;

            after_type:

            $value = $payload['version'] ?? null;

            if ($value === null) {
                $missingFields[] = 'version';
                goto after_version;
            }

            $properties['version'] = $value;

            after_version:

            $value = $payload['worldmap'] ?? null;

            if ($value === null) {
                $missingFields[] = 'worldmap';
                goto after_worldmap;
            }

            $properties['worldmap'] = $value;

            after_worldmap:

            $value = $payload['tiles'] ?? null;

            if ($value === null) {
                $missingFields[] = 'tiles';
                goto after_tiles;
            }

            if (is_array($value[array_key_first($value)] ?? false)) {
                try {
                    $this->hydrationStack[] = 'tiles';
                    $value = $this->hydrateObjects('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $value)->toArray();
                } finally {
                    array_pop($this->hydrationStack);
                }
            }

            $properties['tiles'] = $value;

            after_tiles:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap', $exception, stack: $this->hydrationStack);
        }
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['fileName'] ?? null;

            if ($value === null) {
                $missingFields[] = 'fileName';
                goto after_fileName;
            }

            $properties['fileName'] = $value;

            after_fileName:

            $value = $payload['offSet'] ?? null;

            if ($value === null) {
                $missingFields[] = 'offSet';
                goto after_offSet;
            }

            if (is_array($value)) {
                try {
                    $this->hydrationStack[] = 'offSet';
                    $value = $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($value);
                } finally {
                    array_pop($this->hydrationStack);
                }
            }

            $properties['offSet'] = $value;

            after_offSet:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $exception, stack: $this->hydrationStack);
        }
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['x'] ?? null;

            if ($value === null) {
                $missingFields[] = 'x';
                goto after_x;
            }

            $properties['x'] = $value;

            after_x:

            $value = $payload['y'] ?? null;

            if ($value === null) {
                $missingFields[] = 'y';
                goto after_y;
            }

            $properties['y'] = $value;

            after_y:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet', $exception, stack: $this->hydrationStack);
        }
    }

    private function serializeViaTypeMap(string $accessor, object $object, array $payloadToTypeMap): array
    {
        foreach ($payloadToTypeMap as $payloadType => [$valueType, $method]) {
            if (is_a($object, $valueType)) {
                return [$accessor => $payloadType] + $this->{$method}($object);
            }
        }

        throw new \LogicException('No type mapped for object of class: ' . get_class($object));
    }

    public function serializeObject(object $object): mixed
    {
        return $this->serializeObjectOfType($object, get_class($object));
    }

    /**
     * @template T
     *
     * @param T               $object
     * @param class-string<T> $className
     */
    public function serializeObjectOfType(object $object, string $className): mixed
    {
        try {
            return match($className) {
            'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap' => $this->serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap($object),
                default => throw new \LogicException("No serialization defined for $className"),
            };
        } catch (\Throwable $exception) {
            throw UnableToSerializeObject::dueToError($className, $exception);
        }
    }

    private function serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap(mixed $object): mixed
    {
        \assert($object instanceof \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap);
        $result = [];

        $type = $object->type;
        after_type:        $result['type'] = $type;

        $version = $object->version;
        after_version:        $result['version'] = $version;

        $worldmap = $object->worldmap;
        after_worldmap:        $result['worldmap'] = $worldmap;

        $tiles = $object->tiles;
        static $tilesSerializer0;

        if ($tilesSerializer0 === null) {
            $tilesSerializer0 = new \EventSauce\ObjectHydrator\PropertySerializers\SerializeArrayItems(...array (
));
        }

        $tiles = $tilesSerializer0->serialize($tiles, $this);
        after_tiles:        $result['tiles'] = $tiles;

        return $result;
    }

    /**
     * @template T
     *
     * @param class-string<T> $className
     * @param iterable<array> $payloads;
     *
     * @return IterableList<T>
     *
     * @throws UnableToHydrateObject
     */
    public function hydrateObjects(string $className, iterable $payloads): IterableList
    {
        return new IterableList($this->doHydrateObjects($className, $payloads));
    }

    private function doHydrateObjects(string $className, iterable $payloads): Generator
    {
        foreach ($payloads as $index => $payload) {
            yield $index => $this->hydrateObject($className, $payload);
        }
    }

    /**
     * @template T
     *
     * @param class-string<T> $className
     * @param iterable<array> $payloads;
     *
     * @return IterableList<T>
     *
     * @throws UnableToSerializeObject
     */
    public function serializeObjects(iterable $payloads): IterableList
    {
        return new IterableList($this->doSerializeObjects($payloads));
    }

    private function doSerializeObjects(iterable $objects): Generator
    {
        foreach ($objects as $index => $object) {
            yield $index => $this->serializeObject($object);
        }
    }
}
```

When I pass `Tile` and `OffSet` to the list of to be generated Hydrators like this:
```php
$hydratorGenerator = new ObjectMapperCodeGenerator();
$code              = $hydratorGenerator->dump([
    \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap::class,
	\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile::class,
	\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet::class,
], Hydrator::class);
file_put_contents($rootPath . '/src/Generated/Hydrator.php', $code);
```

I'm getting the expected object mapper class:

```php
<?php

declare(strict_types=1);

use EventSauce\ObjectHydrator\IterableList;
use EventSauce\ObjectHydrator\ObjectMapper;
use EventSauce\ObjectHydrator\UnableToHydrateObject;
use EventSauce\ObjectHydrator\UnableToSerializeObject;
use Generator;

class Hydrator implements ObjectMapper
{
    private array $hydrationStack = [];
    public function __construct() {}

    /**
     * @template T of object
     * @param class-string<T> $className
     * @return T
     */
    public function hydrateObject(string $className, array $payload): object
    {
        return match($className) {
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile($payload),
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($payload),
                'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap' => $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap($payload),
            default => throw UnableToHydrateObject::noHydrationDefined($className, $this->hydrationStack),
        };
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['fileName'] ?? null;

            if ($value === null) {
                $missingFields[] = 'fileName';
                goto after_fileName;
            }

            $properties['fileName'] = $value;

            after_fileName:

            $value = $payload['offSet'] ?? null;

            if ($value === null) {
                $missingFields[] = 'offSet';
                goto after_offSet;
            }

            if (is_array($value)) {
                try {
                    $this->hydrationStack[] = 'offSet';
                    $value = $this->hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($value);
                } finally {
                    array_pop($this->hydrationStack);
                }
            }

            $properties['offSet'] = $value;

            after_offSet:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $exception, stack: $this->hydrationStack);
        }
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['x'] ?? null;

            if ($value === null) {
                $missingFields[] = 'x';
                goto after_x;
            }

            $properties['x'] = $value;

            after_x:

            $value = $payload['y'] ?? null;

            if ($value === null) {
                $missingFields[] = 'y';
                goto after_y;
            }

            $properties['y'] = $value;

            after_y:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet', $exception, stack: $this->hydrationStack);
        }
    }

    private function hydrateWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap(array $payload): \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap
    {
        $properties = [];
        $missingFields = [];
        try {
            $value = $payload['type'] ?? null;

            if ($value === null) {
                $missingFields[] = 'type';
                goto after_type;
            }

            $properties['type'] = $value;

            after_type:

            $value = $payload['version'] ?? null;

            if ($value === null) {
                $missingFields[] = 'version';
                goto after_version;
            }

            $properties['version'] = $value;

            after_version:

            $value = $payload['worldmap'] ?? null;

            if ($value === null) {
                $missingFields[] = 'worldmap';
                goto after_worldmap;
            }

            $properties['worldmap'] = $value;

            after_worldmap:

            $value = $payload['tiles'] ?? null;

            if ($value === null) {
                $missingFields[] = 'tiles';
                goto after_tiles;
            }

            if (is_array($value[array_key_first($value)] ?? false)) {
                try {
                    $this->hydrationStack[] = 'tiles';
                    $value = $this->hydrateObjects('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile', $value)->toArray();
                } finally {
                    array_pop($this->hydrationStack);
                }
            }

            $properties['tiles'] = $value;

            after_tiles:

        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap', $exception, stack: $this->hydrationStack);
        }

        if (count($missingFields) > 0) {
            throw UnableToHydrateObject::dueToMissingFields(\WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap::class, $missingFields, stack: $this->hydrationStack);
        }

        try {
            return new \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap(...$properties);
        } catch (\Throwable $exception) {
            throw UnableToHydrateObject::dueToError('WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap', $exception, stack: $this->hydrationStack);
        }
    }

    private function serializeViaTypeMap(string $accessor, object $object, array $payloadToTypeMap): array
    {
        foreach ($payloadToTypeMap as $payloadType => [$valueType, $method]) {
            if (is_a($object, $valueType)) {
                return [$accessor => $payloadType] + $this->{$method}($object);
            }
        }

        throw new \LogicException('No type mapped for object of class: ' . get_class($object));
    }

    public function serializeObject(object $object): mixed
    {
        return $this->serializeObjectOfType($object, get_class($object));
    }

    /**
     * @template T
     *
     * @param T               $object
     * @param class-string<T> $className
     */
    public function serializeObjectOfType(object $object, string $className): mixed
    {
        try {
            return match($className) {
            'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile' => $this->serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile($object),
            'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet' => $this->serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($object),
            'WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap' => $this->serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap($object),
                default => throw new \LogicException("No serialization defined for $className"),
            };
        } catch (\Throwable $exception) {
            throw UnableToSerializeObject::dueToError($className, $exception);
        }
    }

    private function serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile(mixed $object): mixed
    {
        \assert($object instanceof \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile);
        $result = [];

        $fileName = $object->fileName;
        after_fileName:        $result['fileName'] = $fileName;

        $offSet = $object->offSet;
        $offSet = $this->serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet($offSet);
        after_offSet:        $result['offSet'] = $offSet;

        return $result;
    }

    private function serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap⚡️Tile⚡️OffSet(mixed $object): mixed
    {
        \assert($object instanceof \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap\Tile\OffSet);
        $result = [];

        $x = $object->x;
        after_x:        $result['x'] = $x;

        $y = $object->y;
        after_y:        $result['y'] = $y;

        return $result;
    }

    private function serializeObjectWyriHaximus⚡️Apps⚡️WorldOfWarcraft⚡️DataMiner⚡️Images⚡️Worldmap⚡️Full⚡️Worldmap(mixed $object): mixed
    {
        \assert($object instanceof \WyriHaximus\Apps\WorldOfWarcraft\DataMiner\Images\Worldmap\Full\Worldmap);
        $result = [];

        $type = $object->type;
        after_type:        $result['type'] = $type;

        $version = $object->version;
        after_version:        $result['version'] = $version;

        $worldmap = $object->worldmap;
        after_worldmap:        $result['worldmap'] = $worldmap;

        $tiles = $object->tiles;
        static $tilesSerializer0;

        if ($tilesSerializer0 === null) {
            $tilesSerializer0 = new \EventSauce\ObjectHydrator\PropertySerializers\SerializeArrayItems(...array (
));
        }

        $tiles = $tilesSerializer0->serialize($tiles, $this);
        after_tiles:        $result['tiles'] = $tiles;

        return $result;
    }

    /**
     * @template T
     *
     * @param class-string<T> $className
     * @param iterable<array> $payloads;
     *
     * @return IterableList<T>
     *
     * @throws UnableToHydrateObject
     */
    public function hydrateObjects(string $className, iterable $payloads): IterableList
    {
        return new IterableList($this->doHydrateObjects($className, $payloads));
    }

    private function doHydrateObjects(string $className, iterable $payloads): Generator
    {
        foreach ($payloads as $index => $payload) {
            yield $index => $this->hydrateObject($className, $payload);
        }
    }

    /**
     * @template T
     *
     * @param class-string<T> $className
     * @param iterable<array> $payloads;
     *
     * @return IterableList<T>
     *
     * @throws UnableToSerializeObject
     */
    public function serializeObjects(iterable $payloads): IterableList
    {
        return new IterableList($this->doSerializeObjects($payloads));
    }

    private function doSerializeObjects(iterable $objects): Generator
    {
        foreach ($objects as $index => $object) {
            yield $index => $this->serializeObject($object);
        }
    }
}
```

This change set ensures those nested DTOs are also picked up for the serializer as with the hydrator.

The following code was used to quickly proof the new code would work before creating tests:

```php
<?php declare(strict_types=1);

require_once __DIR__ . '/vendor/autoload.php';

final class ChildObject
{
    public function __construct(
        public readonly string $value,
    ) {}
}

final class ParentObject
{
    /**
     * @param ChildObject[] $list
     */
    public function __construct(
        public readonly array $list,
    ) {}
}

$mapper = new \EventSauce\ObjectHydrator\ObjectMapperUsingReflection();

$object = $mapper->hydrateObject(ParentObject::class, [
    'list' => [
        ['value' => 'one'],
        ['value' => 'two'],
    ],
]);

var_export($object);

var_export($mapper->serializeObject($object));

$dumper = new \EventSauce\ObjectHydrator\ObjectMapperCodeGenerator();
$classesToDump = [ParentObject::class];

$code = $dumper->dump($classesToDump, 'Yolo');

echo $code;
```