### PR TITLE
Fix serialisation/hydration symmetry of list items with registered casters/serialisers for their types

### DIFF
--- a/src/DefinitionProvider.php
+++ b/src/DefinitionProvider.php
@@ -12,6 +12,7 @@ use ReflectionParameter;
 use ReflectionProperty;
 use ReflectionUnionType;
 use function array_key_exists;
+use function array_key_first;
 use function array_reverse;
 use function count;
 use function is_a;
@@ -99,7 +100,19 @@ final class DefinitionProvider
                 }
 
                 if (is_a($attributeName, PropertyCaster::class, true)) {
-                    $casters[] = [$attributeName, $attribute->getArguments()];
+                    $args = $attribute->getArguments();
+
+                    if (is_a($attributeName, PropertyCasters\CastListToType::class, true)   ) {
+                        $casterForItemList = $this->defaultCasters->casterFor($args[0] ?? $args['propertyType']);
+
+                        if ($casterForItemList !== null) {
+                            $args['itemCasterConfig'] = $casterForItemList;
+                        } else {
+                            unset($args[2], $args['itemCasterConfig']);
+                        }
+                    }
+
+                    $casters[] = [$attributeName, $args];
                 }
             }
 

--- a/src/Fixtures/ClassThatCastsListsOfTypesWithCustomCasters.php
+++ b/src/Fixtures/ClassThatCastsListsOfTypesWithCustomCasters.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EventSauce\ObjectHydrator\Fixtures;
+
+use DateTimeImmutable;
+use EventSauce\ObjectHydrator\PropertyCasters\CastListToType;
+
+final readonly class ClassThatCastsListsOfTypesWithCustomCasters
+{
+    public function __construct(
+        #[CastListToType(DateTimeImmutable::class)]
+        public array $dates,
+    ) {
+    }
+}

--- a/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
+++ b/src/IntegrationTests/HydratingSerializedObjectsTestCase.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace EventSauce\ObjectHydrator\IntegrationTests;
 
+use DateTimeImmutable;
+use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsOfTypesWithCustomCasters;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToBasedOnDocComments;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListsToDifferentTypes;
 use EventSauce\ObjectHydrator\Fixtures\ClassThatCastsListToScalarType;
@@ -103,6 +105,20 @@ abstract class HydratingSerializedObjectsTestCase extends TestCase
             [
                 'first' => ['type' => 'list', 'values' => ClassWithCamelCaseProperty::class],
                 'second' => ['type' => 'list', 'values' => ClassWithPropertyCasting::class],
+            ],
+        ];
+
+        yield 'class with list of dates' => [
+            ClassThatCastsListsOfTypesWithCustomCasters::class,
+            [
+                'dates' => [
+                    '2026-01-01 00:00:00.000000+0000',
+                    '2026-01-02 00:00:00.000000+0000',
+                    '2026-01-03 00:00:00.000000+0000',
+                ],
+            ],
+            [
+                'dates' => ['type' => 'list', 'values' => DateTimeImmutable::class],
             ],
         ];
 

--- a/src/PropertyCasters/CastListToType.php
+++ b/src/PropertyCasters/CastListToType.php
@@ -21,10 +21,12 @@ final class CastListToType implements PropertyCaster, PropertySerializer
 
     private bool $nativePropertyType;
     private bool $isEnum;
+    private ?PropertyCaster $itemCaster = null;
 
     public function __construct(
         private string $propertyType,
         private ?string $serializedType = null,
+        private ?array $itemCasterConfig = null,
     )
     {
         $this->nativePropertyType = in_array($this->propertyType, self::NATIVE_TYPES);
@@ -40,9 +42,12 @@ final class CastListToType implements PropertyCaster, PropertySerializer
         }
         if ($this->isEnum) {
             return $this->castToEnums($value);
-        } else {
-            return $this->castToObjectType($value, $hydrator);
         }
+        if ($this->itemCaster() instanceof PropertyCaster) {
+            return $this->castViaCustomLogic($value, $hydrator);
+        }
+
+        return $this->castToObjectType($value, $hydrator);
     }
 
     /**
@@ -65,6 +70,27 @@ final class CastListToType implements PropertyCaster, PropertySerializer
         }
 
         return $value;
+    }
+
+    private function castViaCustomLogic(array $value, ObjectMapper $hydrator): array
+    {
+        $itemCaster = $this->itemCaster();
+        assert($itemCaster instanceof PropertyCaster);
+
+        foreach ($value as $i => $item) {
+            $value[$i] = $itemCaster->cast($item, $hydrator);
+        }
+
+        return $value;
+    }
+
+    private function itemCaster(): ?PropertyCaster
+    {
+        if ($this->itemCasterConfig === null) {
+            return null;
+        }
+
+        return $this->itemCaster ??= new ($this->itemCasterConfig[0])(...$this->itemCasterConfig[1]);
     }
 
     private function castToEnums(array $value): array


### PR DESCRIPTION
`#[CastListToType]` defers the serialisation of list items to `$hydrator->serializeObject()`, which will properly handle registered serialisers for list items based on their types. The hydration, however, breaks as it assumes the input will always be an array.

That assumption is broken when dealing with things like `DateTimeImmutable` or `UuidInterface`, as both https://github.com/EventSaucePHP/ObjectHydrator/blob/main/src/PropertyCasters/CastToDateTimeImmutable.php and https://github.com/EventSaucePHP/ObjectHydrator/blob/main/src/PropertyCasters/CastToUuid.php use `string` to represent their input/output.

Changing everything around `ObjectMapper#serializeObject()` so that it can use `mixed` as input is a massive BC-break - and opens an undesired can of worms.

This tries to address the symmetry issue with the minimal disruption on the public API, accepting an additional parameter on `#[CastListToType]` **that's always overridden to avoid unexpected injection of arguments**.